### PR TITLE
#49: publication_date is now correct format

### DIFF
--- a/py_mmd_tools/nc_to_mmd.py
+++ b/py_mmd_tools/nc_to_mmd.py
@@ -520,7 +520,7 @@ class Nc_to_mmd(object):
             others = self.separate_repeated(True, eval('ncin.%s' %acdd_other))
         data = []
         for i in range(len(publication_dates)):
-            publication_date = publication_dates[i]
+            publication_date = parse(publication_dates[i]).strftime('%Y-%m-%d')
             title = titles[i]
             if len(urls)<=i:
                 url = ''

--- a/tests/test_nc_to_mmd.py
+++ b/tests/test_nc_to_mmd.py
@@ -527,5 +527,15 @@ class TestNC2MMD(unittest.TestCase):
         self.assertEqual(md.missing_attributes['errors'][0],
                 'summary is a required ACDD attribute')
 
+    def test_publication_date(self):
+        format = '%Y-%m-%d'
+        mmd_yaml = yaml.load(resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader)
+        nc2mmd = Nc_to_mmd('tests/data/reference_nc.nc')
+        ncin = Dataset(nc2mmd.netcdf_product)
+        value = nc2mmd.get_dataset_citations(mmd_yaml['dataset_citation'], ncin)
+        dt = datetime.datetime.strptime(value[0]['publication_date'], format)
+        self.assertEqual(dt, datetime.datetime(2020, 11, 27, 0, 0))
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Summary**: Fixed format of publication_date

**Related issue**: #49 

**Suggested reviewer(s)**: @ferrighi 

**Reviewer checklist**:

- [ ] The headers of all files contain a reference to the repository license (i.e., "License: This file is part of py-mmd-tools, licensed under the Apache License 2.0 (https://www.apache.org/licenses/LICENSE-2.0)")
- [ ] 100% test coverage of new code - meaning:
    - [ ] The overall test coverage increased or remained the same as before
    - [ ] Every function is accompanied with a test suite
    - [ ] Tests are both positive (testing that the function work as intended with valid data) and negative (testing that the function behaves as expected with invalid data, e.g., that correct exceptions are thrown)
    - [ ] Functions with optional arguments have separate tests for all options
- [ ] Examples are supported by doctests
- [ ] All tests are passing
- [ ] All names (e.g., files, classes, functions, variables) are explicit
- [ ] Documentation (as docstrings) is complete and understandable

The checklist is based on the S-ENDA conventions and definition of done (see https://s-enda-documentation.readthedocs.io/en/latest/general_conventions.html). The above points are not necessarily relevant to all contributions. In that case, please add a short explanation to help the reviewer.
