### PR TITLE
#66: removed mmd namespace in front of relation_type

### DIFF
--- a/py_mmd_tools/templates/mmd_template.xml
+++ b/py_mmd_tools/templates/mmd_template.xml
@@ -144,7 +144,7 @@
   {% endif %}
   {% if data['related_dataset'] %}
     {% for related_dataset in data['related_dataset'] %}
-  <mmd:related_dataset mmd:relation_type="{{ related_dataset['relation_type'] }}">{{ related_dataset['id'] }}</mmd:related_dataset>
+  <mmd:related_dataset relation_type="{{ related_dataset['relation_type'] }}">{{ related_dataset['id'] }}</mmd:related_dataset>
     {% endfor %}
   {% endif %}
   {% if data['storage_information'] %}


### PR DESCRIPTION
**Summary**: mmd relation_type is now according to the docs - needed to remove "mmd:"

**Related issue**: #66 

**Suggested reviewer(s)**: @ferrighi 

**Reviewer checklist**:

- [ ] The headers of all files contain a reference to the repository license (i.e., "License: This file is part of py-mmd-tools, licensed under the Apache License 2.0 (https://www.apache.org/licenses/LICENSE-2.0)")
- [ ] 100% test coverage of new code - meaning:
    - [ ] The overall test coverage increased or remained the same as before
    - [ ] Every function is accompanied with a test suite
    - [ ] Tests are both positive (testing that the function work as intended with valid data) and negative (testing that the function behaves as expected with invalid data, e.g., that correct exceptions are thrown)
    - [ ] Functions with optional arguments have separate tests for all options
- [ ] Examples are supported by doctests
- [ ] All tests are passing
- [ ] All names (e.g., files, classes, functions, variables) are explicit
- [ ] Documentation (as docstrings) is complete and understandable

The checklist is based on the S-ENDA conventions and definition of done (see https://s-enda-documentation.readthedocs.io/en/latest/general_conventions.html). The above points are not necessarily relevant to all contributions. In that case, please add a short explanation to help the reviewer.
