### PR TITLE
#68: removed defaults for temporal and geographic extent, made it pos…

### DIFF
--- a/py_mmd_tools/mmd_elements.yaml
+++ b/py_mmd_tools/mmd_elements.yaml
@@ -71,9 +71,9 @@ abstract:
 
 temporal_extent:
   maxOccurs: unbounded
-  minOccurs: '0' # relaxed requirement to allow external datasets with missing start_date
+  minOccurs: '1'
   start_date:
-    default: '1850-01-01T00:00:00Z'
+    #default: '1850-01-01T00:00:00Z'
     acdd: time_coverage_start
     separator: ','
   end_date:
@@ -91,22 +91,22 @@ geographic_extent:
     north:
       maxOccurs: '1'
       minOccurs: '1'
-      default: 90
+      #default: 90
       acdd: geospatial_lat_max
     south:
       maxOccurs: '1'
       minOccurs: '1'
-      default: -90
+      #default: -90
       acdd: geospatial_lat_min
     east:
       maxOccurs: '1'
       minOccurs: '1'
-      default: 180
+      #default: 180
       acdd: geospatial_lon_max
     west:
       maxOccurs: '1'
       minOccurs: '1'
-      default: -180
+      #default: -180
       acdd: geospatial_lon_min
   polygon:
     maxOccurs: '1'

--- a/py_mmd_tools/nc_to_mmd.py
+++ b/py_mmd_tools/nc_to_mmd.py
@@ -180,13 +180,14 @@ class Nc_to_mmd(object):
             if acdd in ncin.ncattrs():
                 data = self.separate_repeated(repetition_allowed, eval('ncin.%s' %acdd), separator)
             elif required:
-                # We allow some missing elements (in particular for datasets from outside MET)
-                if default:
-                    data = default
-                    self.missing_attributes['warnings'].append('Using default value %s for %s' %(str(default), acdd))
-                else:
-                    data = None
-                    self.missing_attributes['errors'].append('%s is a required attribute' %acdd)
+                ## We may allow some missing elements (in particular for datasets from outside MET) but this 
+                ## is currently not needed. The below code is therefore commented..
+                #if default:
+                #    data = default
+                #    self.missing_attributes['warnings'].append('Using default value %s for %s' %(str(default), acdd))
+                #else:
+                data = None
+                self.missing_attributes['errors'].append('%s is a required attribute' %acdd)
 
         return data
 

--- a/py_mmd_tools/nc_to_mmd.py
+++ b/py_mmd_tools/nc_to_mmd.py
@@ -166,11 +166,11 @@ class Nc_to_mmd(object):
                     data = default
                     if required:
                         self.missing_attributes['warnings'].append('Using default value %s for %s' %(str(default), mmd_element_name))
-                elif not required:
-                    if repetition_allowed:
-                        return []
-                    else:
-                        return None
+                elif not required and not repetition_allowed:
+                    data = None
+                #        return data
+                #    else:
+                #        return None
             else:
                 data = {}
                 for key, val in mmd_element.items():
@@ -181,10 +181,12 @@ class Nc_to_mmd(object):
                 data = self.separate_repeated(repetition_allowed, eval('ncin.%s' %acdd), separator)
             elif required:
                 # We allow some missing elements (in particular for datasets from outside MET)
-                data = default
-                self.missing_attributes['warnings'].append('Using default value %s for %s' %(str(default), mmd_element_name))
-            else:
-                return
+                if default:
+                    data = default
+                    self.missing_attributes['warnings'].append('Using default value %s for %s' %(str(default), acdd))
+                else:
+                    data = None
+                    self.missing_attributes['errors'].append('%s is a required attribute' %acdd)
 
         return data
 
@@ -253,7 +255,7 @@ class Nc_to_mmd(object):
             abstracts = self.separate_repeated(True, eval('ncin.%s' %acdd), separator)
         else:
             self.missing_attributes['errors'].append('%s is a required ACDD attribute' %acdd)
-            return
+            return data
         for abstract in abstracts:
             data.append({'abstract': abstract, 'lang': mmd_element['lang']['default']})
         return data
@@ -262,10 +264,12 @@ class Nc_to_mmd(object):
         separator = mmd_element['start_date'].pop('separator')
         acdd_start = mmd_element['start_date'].pop('acdd')
         acdd_end = mmd_element['end_date'].pop('acdd')
+        data = []
         if acdd_start in ncin.ncattrs():
             start_dates = [eval('ncin.%s' %acdd_start)]
         else:
-            start_dates = [mmd_element['start_date'].pop('default')]
+            self.missing_attributes['errors'].append('%s is a required ACDD attribute' %acdd_start)
+            return data
         if acdd_end in ncin.ncattrs():
             end_dates = [eval('ncin.%s' %acdd_end)]
         else:
@@ -281,7 +285,6 @@ class Nc_to_mmd(object):
             except ParserError:
                 end_dates = self.separate_repeated(True, end_dates[0], separator)
 
-        data = []
         for i in range(len(start_dates)):
             t_ext = {}
             t_ext['start_date'] = start_dates[i]
@@ -503,6 +506,7 @@ class Nc_to_mmd(object):
         it arrives.
         """
         acdd_author = mmd_element['author'].pop('acdd')
+        authors = []
         if acdd_author in ncin.ncattrs():
             authors = eval('ncin.%s' %acdd_author)
 
@@ -605,15 +609,39 @@ class Nc_to_mmd(object):
         return data
 
     def to_mmd(self, netcdf_local_path='', *args, **kwargs):
+        """Method for parsing and mapping NetCDF attributes to MMD.
+
+        Some times the data producers have missed some required elements in their netCDF attributes. These are possible to override by adding certain optional keyword arguments (see below parameter list).
+
+        Parameters
+        ----------
+        netcdf_local_path   : str, optional
+        time_coverage_start : str, optional
+            The start date and time, in iso8601 format, for data collection or model coverage.
+        time_coverage_end   : str, optional
+            The end date and time, in iso8601 format, for data collection or model coverage.
+        geographic_extent_rectangle : dict, optional
+            The geographic extent of the datasets defined as a rectangle in lat/lon projection. The extent is defined using the following child elements: {
+                'geospatial_lat_max': geospatial_lat_max - The northernmost point covered by the dataset.
+                'geospatial_lat_min': geospatial_lat_min - The southernmost point covered by the dataset.
+                'geospatial_lon_min': geospatial_lon_min - The easternmost point covered by the dataset.
+                'geospatial_lon_max': geospatial_lon_max - The westernmost point covered by the dataset.
+            }
+
+        This list can be extended but requires some new code...
         """
-        Method for parsing content of NetCDF file, mapping discovery
-        metadata to MMD, and writes MMD to disk.
-        """
+        # kwargs that were not added in the function def:
+        time_coverage_start = kwargs.pop('time_coverage_start', '')
+        time_coverage_end = kwargs.pop('time_coverage_end', '')
+        geographic_extent_rectangle = kwargs.pop('geographic_extent_rectangle', '')
+
+        # Open netcdf file for reading
         try:
             ncin = Dataset(self.netcdf_product)
         except OSError:
             ncin = Dataset(self.netcdf_product+'#fillmismatch')
 
+        # Get list of MMD elements
         self.metadata = {}
         mmd_yaml = yaml.load(resource_string(self.__module__.split('.')[0], 'mmd_elements.yaml'), Loader=yaml.FullLoader)
 
@@ -624,14 +652,30 @@ class Nc_to_mmd(object):
                 mmd_yaml.pop('last_metadata_update'), ncin)
         self.metadata['title'] = self.get_titles(mmd_yaml.pop('title'), ncin)
         self.metadata['abstract'] = self.get_abstracts(mmd_yaml.pop('abstract'), ncin)
-        self.metadata['temporal_extent'] = self.get_temporal_extents(mmd_yaml.pop('temporal_extent'), ncin)
+        if time_coverage_start:
+            self.metadata['temporal_extent'] = {'start_date': time_coverage_start}
+            if time_coverage_end:
+                self.metadata['temporal_extent']['end_date'] = time_coverage_end
+            mmd_yaml.pop('temporal_extent')
+        else:
+            self.metadata['temporal_extent'] = self.get_temporal_extents(mmd_yaml.pop('temporal_extent'), ncin)
         self.metadata['personnel'] = self.get_personnel(mmd_yaml.pop('personnel'), ncin)
         self.metadata['keywords'] = self.get_keywords(mmd_yaml.pop('keywords'), ncin)
         self.metadata['project'] = self.get_projects(mmd_yaml.pop('project'), ncin)
         self.metadata['platform'] = self.get_platforms(mmd_yaml.pop('platform'), ncin)
         self.metadata['dataset_citation'] = self.get_dataset_citations(mmd_yaml.pop('dataset_citation'), ncin)
         self.metadata['related_dataset'] = self.get_related_dataset(mmd_yaml.pop('related_dataset'), ncin)
-
+        if geographic_extent_rectangle:
+            self.metadata['geographic_extent'] = {
+                    'rectangle': {
+                        'srsName': 'EPSG:4326',
+                        'north': geographic_extent_rectangle['geospatial_lat_max'],
+                        'south': geographic_extent_rectangle['geospatial_lat_min'],
+                        'west': geographic_extent_rectangle['geospatial_lon_min'],
+                        'east': geographic_extent_rectangle['geospatial_lon_max']
+                    }
+                }
+            mmd_yaml.pop('geographic_extent')
         # Data access should not be read from the netCDF-CF file
         _ = mmd_yaml.pop('data_access')
         # Add OPeNDAP data_access if "netcdf_product" is OPeNDAP url

--- a/py_mmd_tools/nc_to_mmd.py
+++ b/py_mmd_tools/nc_to_mmd.py
@@ -266,20 +266,20 @@ class Nc_to_mmd(object):
         acdd_start = mmd_element['start_date'].pop('acdd')
         acdd_end = mmd_element['end_date'].pop('acdd')
         data = []
+        start_dates = []
         if acdd_start in ncin.ncattrs():
             start_dates = [eval('ncin.%s' %acdd_start)]
         else:
             self.missing_attributes['errors'].append('%s is a required ACDD attribute' %acdd_start)
-            return data
+        end_dates = []
         if acdd_end in ncin.ncattrs():
             end_dates = [eval('ncin.%s' %acdd_end)]
-        else:
-            end_dates = []
         
-        try:
-            _ = parse(start_dates[0])
-        except ParserError:
-            start_dates = self.separate_repeated(True, start_dates[0], separator)
+        if start_dates:
+            try:
+                _ = parse(start_dates[0])
+            except ParserError:
+                start_dates = self.separate_repeated(True, start_dates[0], separator)
         if end_dates:
             try:
                 _ = parse(end_dates[0])

--- a/tests/test_nc_to_mmd.py
+++ b/tests/test_nc_to_mmd.py
@@ -529,7 +529,7 @@ class TestNC2MMD(unittest.TestCase):
             md = Nc_to_mmd(file, output_file=tested)
             md.to_mmd()
             valid = xsd_check(xml_file=tested, xsd_schema=self.reference_xsd)
-            self.assertTrue(valid[0])
+            self.assertTrue(valid[0], msg='%s'%valid[1])
 
     def test_create_mmd_missing_publisher_url(self):
         mmd_yaml = yaml.load(resource_string('py_mmd_tools', 'mmd_elements.yaml'), 

--- a/tests/test_nc_to_mmd.py
+++ b/tests/test_nc_to_mmd.py
@@ -50,15 +50,25 @@ class TestNC2MMD(unittest.TestCase):
     ##    self.assertTrue(mock_init.called)
     ##    self.assertTrue(mock_to_mmd.called)
 
-    def test_use_defaults_for_geographic_extent(self):
+    def test_missing_geographic_extent(self):
         mmd_yaml = yaml.load(resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader)
         nc2mmd = Nc_to_mmd('tests/data/reference_nc_missing_attrs.nc')
         ncin = Dataset(nc2mmd.netcdf_product)
         value = nc2mmd.get_acdd_metadata(mmd_yaml['geographic_extent'], ncin, 'geographic_extent')
-        self.assertEqual(value['rectangle']['north'], 90)
-        self.assertEqual(value['rectangle']['south'], -90)
-        self.assertEqual(value['rectangle']['east'], 180)
-        self.assertEqual(value['rectangle']['west'], -180)
+        self.assertEqual(value['rectangle']['north'], None)
+        self.assertEqual(nc2mmd.missing_attributes['errors'][0], 'geospatial_lat_max is a required attribute')
+
+    def test_missing_geographic_extent_but_provided_as_kwarg(self):
+        mmd_yaml = yaml.load(resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader)
+        nc2mmd = Nc_to_mmd('tests/data/reference_nc_missing_attrs.nc')
+        with self.assertRaises(AttributeError):
+            nc2mmd.to_mmd(geographic_extent_rectangle={
+                'geospatial_lat_max': 90,
+                'geospatial_lat_min': -90,
+                'geospatial_lon_min': -180,
+                'geospatial_lon_max': 180
+                })
+        self.assertEqual(nc2mmd.metadata['geographic_extent']['rectangle']['north'], 90)
 
     def test_collection_not_set(self):
         mmd_yaml = yaml.load(resource_string('py_mmd_tools', 'mmd_elements.yaml'),
@@ -170,12 +180,28 @@ class TestNC2MMD(unittest.TestCase):
         self.assertEqual(value[0]['email'], 'unknown')
         self.assertEqual(value[0]['organisation'], 'unknown')
 
-    def test_use_defaults_for_temporal_extent(self):
+    def test_missing_temporal_extent(self):
         mmd_yaml = yaml.load(resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader)
         nc2mmd = Nc_to_mmd('tests/data/reference_nc_missing_attrs.nc')
         ncin = Dataset(nc2mmd.netcdf_product)
         value = nc2mmd.get_temporal_extents(mmd_yaml['temporal_extent'], ncin)
-        self.assertEqual(value[0]['start_date'], '1850-01-01T00:00:00Z')
+        self.assertEqual(value, [])
+        self.assertEqual(nc2mmd.missing_attributes['errors'][0], 'time_coverage_start is a required ACDD attribute')
+
+    def test_missing_temporal_extent_but_start_provided_as_kwarg(self):
+        mmd_yaml = yaml.load(resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader)
+        nc2mmd = Nc_to_mmd('tests/data/reference_nc_missing_attrs.nc')
+        with self.assertRaises(AttributeError):
+            nc2mmd.to_mmd(time_coverage_start='1850-01-01T00:00:00Z')
+        self.assertEqual(nc2mmd.metadata['temporal_extent']['start_date'], '1850-01-01T00:00:00Z')
+
+    def test_missing_temporal_extent_but_start_and_end_provided_as_kwargs(self):
+        mmd_yaml = yaml.load(resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader)
+        nc2mmd = Nc_to_mmd('tests/data/reference_nc_missing_attrs.nc')
+        with self.assertRaises(AttributeError):
+            nc2mmd.to_mmd(time_coverage_start='1850-01-01T00:00:00Z', time_coverage_end='1950-01-01T00:00:00Z')
+        self.assertEqual(nc2mmd.metadata['temporal_extent']['start_date'], '1850-01-01T00:00:00Z')
+        self.assertEqual(nc2mmd.metadata['temporal_extent']['end_date'], '1950-01-01T00:00:00Z')
 
     def test_temporal_extent_two_startdates(self):
         mmd_yaml = yaml.load(resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader)


### PR DESCRIPTION
…sible to provide them as kwargs, and added tests

**Summary**: It may be incorrect to add temporal and geographic extents as that will be misleading.

**Related issue**: #68 

**Suggested reviewer(s)**: @ferrighi @TAlonglong 

**Reviewer checklist**:

- [ ] The headers of all files contain a reference to the repository license (i.e., "License: This file is part of py-mmd-tools, licensed under the Apache License 2.0 (https://www.apache.org/licenses/LICENSE-2.0)")
- [ ] 100% test coverage of new code - meaning:
    - [ ] The overall test coverage increased or remained the same as before
    - [ ] Every function is accompanied with a test suite
    - [ ] Tests are both positive (testing that the function work as intended with valid data) and negative (testing that the function behaves as expected with invalid data, e.g., that correct exceptions are thrown)
    - [ ] Functions with optional arguments have separate tests for all options
- [ ] Examples are supported by doctests
- [ ] All tests are passing
- [ ] All names (e.g., files, classes, functions, variables) are explicit
- [ ] Documentation (as docstrings) is complete and understandable

The checklist is based on the S-ENDA conventions and definition of done (see https://s-enda-documentation.readthedocs.io/en/latest/general_conventions.html). The above points are not necessarily relevant to all contributions. In that case, please add a short explanation to help the reviewer.
