### PR TITLE
#87: refactored xml_translate method by using xsd_check for validatio…

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE
+recursive-include py_mmd_tools/templates *

--- a/py_mmd_tools/odajson_to_mmd.py
+++ b/py_mmd_tools/odajson_to_mmd.py
@@ -253,7 +253,7 @@ def to_mmd(input_data, output_file, template_file, xsd_validation=False, xsd_sch
         if not pathlib.Path(xsd_schema).is_file():
             raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), xsd_schema)
         else:
-            if not xsd_check(output_file, xsd_schema=xsd_schema)[0]:
+            if not xsd_check(output_file, xsd_schema)[0]:
                 return False
 
     return True

--- a/py_mmd_tools/xml_utils.py
+++ b/py_mmd_tools/xml_utils.py
@@ -114,6 +114,8 @@ def xml_translate(xml_file, xslt):
     """
     if not pathlib.Path(xml_file).exists():
         raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), xml_file)
+    if not pathlib.Path(xslt).exists():
+        raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), xslt)
         
     xml_doc = ET.ElementTree(file=xml_file)
     transform = ET.XSLT(ET.parse(xslt))

--- a/script/xmlconverter.py
+++ b/script/xmlconverter.py
@@ -16,7 +16,7 @@ import pathlib
 import sys
 import parmap
 from lxml.etree import XMLSyntaxError
-from py_mmd_tools.xml_utils import xml_translate
+from py_mmd_tools.xml_utils import xml_translate_and_write
 
 
 
@@ -47,7 +47,7 @@ def translate_and_write(xml_file, xslt, outdir="/tmp"):
     outputfile = pathlib.PurePosixPath(outdir).joinpath(
         pathlib.PurePosixPath(xml_file).name
     )
-    xml_translate(
+    xml_translate_and_write(
         xml_file=xml_file,
         outputfile=outputfile,
         xslt=xslt,

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,11 +26,25 @@ python_requires = >=3.6
 project_urls =
     Source Code = https://github.com/metno/py-mmd-tools
 
-install_requires = ['filehash', 'jinja2',
-                    'lxml==4.5', 'netCDF4>=1.5,<=1.6', 
-                    'numpy', 'pandas', 'parmap',
-                    'python-dateutil', 'pyyaml', 'requests', 'wget',
-                    'xmltodict']
+[options]
+include_package_data = True
+packages = find:
+install_requires = 
+    filehash
+    jinja2
+    lxml>=4.5
+    netCDF4>=1.5,<=1.6
+    numpy
+    pandas
+    parmap
+    pythesint
+    python-dateutil
+    pyyaml
+    requests
+    shapely
+    wget
+    xmltodict
+
 [bdist_wheel]
 universal = 0
 

--- a/tests/data/not_a_valid_mmd.xml
+++ b/tests/data/not_a_valid_mmd.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mmd:mmd xmlns:mmd="http://www.met.no/schema/mmd" xmlns:gml="http://www.opengis.net/gml"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dif="http://gcmd.gsfc.nasa.gov/Aboutus/xml/dif/"
+        xmlns:dc="http://purl.org/dc/elements/1.1/">
+
+<mmd:metadata_identifier>S1A_EW_GRDM_1SDH_20200420T023244_20200420T023348_032205_03B97F_72EB</mmd:metadata_identifier>
+<mmd:abstract xml:lang="en">
+The SENTINEL-1 mission comprises a constellation of two polar-orbiting satellites, operating day and night performing C-band synthetic aperture radar imaging, enabling them to acquire imagery regardless of the weather.
+</mmd:abstract>
+<mmd:metadata_status>Active</mmd:metadata_status>
+<mmd:dataset_production_status>In Work</mmd:dataset_production_status>
+<mmd:collection>NBS</mmd:collection>
+<mmd:last_metadata_update>
+	<mmd:update>
+		<mmd:datetime>2020-04-20T05:42:18.746Z</mmd:datetime>
+		<mmd:type>Created</mmd:type>
+	</mmd:update>
+</mmd:last_metadata_update>
+<mmd:temporal_extent>
+	<mmd:start_date>2020-04-20T02:32:44.006Z</mmd:start_date>
+	<mmd:end_date>2020-04-20T02:33:48.294Z</mmd:end_date>
+</mmd:temporal_extent>
+<mmd:iso_topic_category>climatologyMeteorologyAtmosphere</mmd:iso_topic_category>
+<mmd:iso_topic_category>oceans</mmd:iso_topic_category>
+<mmd:iso_topic_category>imageryBaseMapsEarthCover</mmd:iso_topic_category>
+<mmd:keywords vocabulary="GCMD">
+<mmd:keyword>
+Earth Science > Spectral/Engineering > RADAR > RADAR backscatter
+</mmd:keyword>
+<mmd:keyword>
+Earth Science > Spectral/Engineering > RADAR > RADAR imagery
+</mmd:keyword>
+<mmd:keyword>
+Earth Science > Spectral/Engineering > Microwave > Microwave imagery
+</mmd:keyword>
+</mmd:keywords>
+<mmd:dataset_language>en</mmd:dataset_language>
+<mmd:operational_status>Operational</mmd:operational_status>
+<mmd:geographic_extent>
+	<mmd:rectangle srsName="EPSG:4326">
+		<mmd:north>82.044609</mmd:north>
+		<mmd:south>76.955391</mmd:south>
+		<mmd:west>63.098541</mmd:west>
+		<mmd:east>90.652794</mmd:east>
+	</mmd:rectangle>
+</mmd:geographic_extent>
+
+<mmd:platform>
+        <mmd:short_name>S1A</mmd:short_name>
+        <mmd:long_name>Sentinel-1A</mmd:long_name>
+        <mmd:resource>https://www.wmo-sat.info/oscar/satellites/view/396</mmd:resource>
+        <mmd:orbit_relative>73</mmd:orbit_relative>
+        <mmd:orbit_absolute>32205</mmd:orbit_absolute>
+        <mmd:orbit_direction>descending</mmd:orbit_direction>
+        <mmd:instrument>
+                <mmd:short_name>SAR-C</mmd:short_name>
+                <mmd:long_name>Synthetic Aperture Radar (C-band)</mmd:long_name>
+                <mmd:resource>https://www.wmo-sat.info/oscar/instruments/view/450</mmd:resource>
+                <mmd:mode>EW</mmd:mode>
+                <mmd:polarisation>HH+HV</mmd:polarisation>
+                <mmd:product_type>GRD</mmd:product_type>
+        </mmd:instrument>
+        <mmd:ancillary>
+                <mmd:timeliness>NRT</mmd:timeliness>
+        </mmd:ancillary>
+</mmd:platform>
+
+<mmd:related_information>
+	<mmd:type>Users guide</mmd:type>
+	<mmd:description>URI to a users guide or product manual for the dataset.</mmd:description>
+	<mmd:resource>https://sentinel.esa.int/web/sentinel/missions/sentinel-1</mmd:resource>
+</mmd:related_information>
+
+<mmd:project>
+	<mmd:short_name>NBS</mmd:short_name>
+	<mmd:long_name>Nasjonalt BakkeSegment</mmd:long_name>
+</mmd:project>
+
+<mmd:activity_type>Space Borne Instrument</mmd:activity_type>
+<mmd:data_center>
+	<mmd:data_center_name>
+		<mmd:short_name>METNO</mmd:short_name>
+		<mmd:long_name>Norwegian Meteorological Institute</mmd:long_name>
+	</mmd:data_center_name>
+	<mmd:data_center_url>https://met.no</mmd:data_center_url>
+</mmd:data_center>
+
+<mmd:personnel>
+	<mmd:role>Data center contact</mmd:role>
+	<mmd:name>NBS Helpdesk</mmd:name>
+	<mmd:email>nbs-helpdesk@met.no</mmd:email>
+	<mmd:phone/>
+	<mmd:fax/>
+</mmd:personnel>
+
+<mmd:data_access>
+	<mmd:type>OPeNDAP</mmd:type>
+	<mmd:description>Open-source Project for a Network Data Access Protocol.</mmd:description>
+	<mmd:resource>http://nbstds.met.no/thredds/dodsC/NBS/S1A/2020/04/20/EW/S1A_EW_GRDM_1SDH_20200420T023244_20200420T023348_032205_03B97F_72EB.nc</mmd:resource>
+</mmd:data_access>
+<mmd:data_access>
+	<mmd:type>OGC WMS</mmd:type>
+	<mmd:description>OGC Web Mapping Service, URI to GetCapabilities Document.</mmd:description>
+	<mmd:resource>http://nbswms.met.no/thredds/wms_ql/NBS/S1A/2020/04/20/EW/S1A_EW_GRDM_1SDH_20200420T023244_20200420T023348_032205_03B97F_72EB.nc</mmd:resource>
+	<mmd:wms_layers>
+		<mmd:wms_layer>Amplitude HH polarisation</mmd:wms_layer>
+		<mmd:wms_layer>Amplitude HV polarisation</mmd:wms_layer>
+	</mmd:wms_layers>
+</mmd:data_access>
+<mmd:data_access>
+	<mmd:type>HTTP</mmd:type>
+	<mmd:description>Direct access to the full data file. May require authentication, but should point directly to the data file or a catalogue containing the data.</mmd:description>
+	<mmd:resource>http://nbstds.met.no/thredds/fileServer/NBS/S1A/2020/04/20/EW/S1A_EW_GRDM_1SDH_20200420T023244_20200420T023348_032205_03B97F_72EB.nc</mmd:resource>
+</mmd:data_access>
+<mmd:data_access>
+	<mmd:type>ODATA</mmd:type>
+	<mmd:description>Open Data Protocol.</mmd:description>
+	<mmd:resource>https://colhub.met.no/odata/v1/Products('c393826f-465d-4437-983f-fa2e003214a5')/$value</mmd:resource>
+</mmd:data_access>
+
+<mmd:related_information>
+	<mmd:type>Dataset landing page</mmd:type>
+	<mmd:description>A dataset landing page.</mmd:description>
+	<mmd:resource>http://nbstds.met.no/thredds/catalog/NBS/S1A/2020/04/20/EW/catalog.html?dataset=nbs/S1A/2020/04/20/EW/S1A_EW_GRDM_1SDH_20200420T023244_20200420T023348_032205_03B97F_72EB.nc</mmd:resource>
+</mmd:related_information>
+</mmd:mmd>

--- a/tests/test_nc_to_mmd.py
+++ b/tests/test_nc_to_mmd.py
@@ -534,7 +534,7 @@ class TestNC2MMD(unittest.TestCase):
         tested = tempfile.mkstemp()[1]
         md = Nc_to_mmd(self.reference_nc, output_file=tested)
         md.to_mmd()
-        valid = xsd_check(xml_file=tested, xsd_schema=self.reference_xsd)
+        valid = xsd_check(tested, self.reference_xsd)
         self.assertTrue(valid[0])
 
     def test_get_acdd_metadata_sets_warning_msg(self):
@@ -562,7 +562,7 @@ class TestNC2MMD(unittest.TestCase):
             tested = tempfile.mkstemp()[1]
             md = Nc_to_mmd(file, output_file=tested)
             md.to_mmd()
-            valid = xsd_check(xml_file=tested, xsd_schema=self.reference_xsd)
+            valid = xsd_check(tested, self.reference_xsd)
             self.assertTrue(valid[0], msg='%s'%valid[1])
 
     def test_create_mmd_missing_publisher_url(self):

--- a/tests/test_xml_util.py
+++ b/tests/test_xml_util.py
@@ -22,7 +22,12 @@ class test_pymmdtools(unittest.TestCase):
         self.reference_xsd = os.path.join(os.environ['MMD_PATH'], 'xsd/mmd.xsd')
         self.not_a_file = str(current_dir / 'tests' / 'data' / 'not_a_file.xml')
         self.not_a_valid_xml = str(current_dir / 'tests' / 'data' / 'not_a_valid_xml.xml')
+        self.not_a_valid_mmd = str(current_dir / 'tests' / 'data' / 'not_a_valid_mmd.xml')
  
+    def test_xml_translate_and_write__raises_exception(self):
+        tested = tempfile.mkstemp()[1]
+        self.assertRaises(Exception, xml_translate_and_write, self.not_a_valid_mmd, tested, self.mmd2iso_xslt, True, self.reference_xsd)
+
     def test_xml_check_assertTrue(self):
         self.assertTrue(xml_check(xml_file=self.reference_xml))
 

--- a/tests/test_xml_util.py
+++ b/tests/test_xml_util.py
@@ -2,7 +2,7 @@ import os
 import tempfile
 import unittest
 import pathlib
-from py_mmd_tools.xml_utils import xml_check, xsd_check, xml_translate_and_write
+from py_mmd_tools.xml_utils import xml_check, xsd_check, xml_translate_and_write, xml_translate
 from lxml.etree import XMLSyntaxError
 
 
@@ -51,7 +51,7 @@ class test_pymmdtools(unittest.TestCase):
         self.assertRaises(OSError, xsd_check, self.not_a_file, 
                                                     self.not_a_file)                               
 
-    def test_xml_translate_assertMultiLineEqual_validation_false(self):
+    def test_xml_translate_and_write_assertMultiLineEqual_validation_false(self):
         self.maxDiff = None
         tested = tempfile.mkstemp()[1]
         xml_translate_and_write(
@@ -66,7 +66,7 @@ class test_pymmdtools(unittest.TestCase):
                 self, first=reference_iso_string, second=tested_string
             ) 
 
-    def test_xml_translate_assertMultiLineEqual_validation_true(self):
+    def test_xml_translate_and_write_assertMultiLineEqual_validation_true(self):
         self.maxDiff = None
         tested = tempfile.mkstemp()[1]
         xml_translate_and_write(
@@ -84,7 +84,7 @@ class test_pymmdtools(unittest.TestCase):
                                                     second=tested_string
                                                     )
 
-    def test_xml_translate_assertRaises_FileNotFoundError_opt_xmlfile(self):
+    def test_xml_translate_and_write_assertRaises_FileNotFoundError_opt_xmlfile(self):
         self.maxDiff = None
         tested = tempfile.mkstemp()[1]
         self.assertRaises(FileNotFoundError, 
@@ -95,18 +95,23 @@ class test_pymmdtools(unittest.TestCase):
                             True, 
                             self.reference_xsd) 
 
+    def test_xml_translate__assertRaises_FileNotFoundError_opt_xml(self):
+        self.assertRaises(FileNotFoundError, xml_translate, self.not_a_file, self.mmd2iso_xslt)
 
-    def test_xml_translate_assertRaises_FileNotFoundError_opt_xslt(self):
+    def test_xml_translate__assertRaises_FileNotFoundError_opt_xslt(self):
+        self.assertRaises(FileNotFoundError, xml_translate, self.reference_xml, self.not_a_file)
+
+    def test_xml_translate_and_write_assertRaises_FileNotFoundError_opt_xslt(self):
         self.maxDiff = None
         tested = tempfile.mkstemp()[1]
         self.assertRaises(FileNotFoundError, xml_translate_and_write, self.reference_xml, tested, self.not_a_file, True, self.reference_xsd)
 
-    def test_xml_translate_assertRaises_FileNotFoundError_opt_xsdschema(self):
+    def test_xml_translate_and_write_assertRaises_FileNotFoundError_opt_xsdschema(self):
         self.maxDiff = None
         tested = tempfile.mkstemp()[1]
         self.assertRaises(FileNotFoundError, xml_translate_and_write, self.reference_xml, tested, self.mmd2iso_xslt, True, self.not_a_file)
 
-    def test_xml_translate_assertRaises_TypeError(self):
+    def test_xml_translate_and_write_assertRaises_TypeError(self):
         self.maxDiff = None
         tested = tempfile.mkstemp()[1]
         self.assertRaises(TypeError, xml_translate_and_write, self.reference_xml, tested, self.mmd2iso_xslt, True)

--- a/tests/test_xml_util.py
+++ b/tests/test_xml_util.py
@@ -2,7 +2,7 @@ import os
 import tempfile
 import unittest
 import pathlib
-from py_mmd_tools.xml_utils import xml_check, xsd_check, xml_translate
+from py_mmd_tools.xml_utils import xml_check, xsd_check, xml_translate_and_write
 from lxml.etree import XMLSyntaxError
 
 
@@ -33,8 +33,7 @@ class test_pymmdtools(unittest.TestCase):
         self.assertRaises(XMLSyntaxError, xml_check, self.not_a_valid_xml)        
 
     def test_xsl_check_assertTrue(self):
-        self.assertTrue(xsd_check(xml_file=self.reference_xml, 
-                                            xsd_schema=self.reference_xsd)[0])
+        self.assertTrue(xsd_check(self.reference_xml, self.reference_xsd)[0])
 
     def test_xsl_check_assertRaises_XMLSyntaxError_opt_xslschema(self):
         self.assertRaises(XMLSyntaxError, xsd_check, self.reference_xml, 
@@ -55,7 +54,7 @@ class test_pymmdtools(unittest.TestCase):
     def test_xml_translate_assertMultiLineEqual_validation_false(self):
         self.maxDiff = None
         tested = tempfile.mkstemp()[1]
-        xml_translate(
+        xml_translate_and_write(
             xml_file=self.reference_xml,
             outputfile=tested,
             xslt=self.mmd2iso_xslt,
@@ -70,7 +69,7 @@ class test_pymmdtools(unittest.TestCase):
     def test_xml_translate_assertMultiLineEqual_validation_true(self):
         self.maxDiff = None
         tested = tempfile.mkstemp()[1]
-        xml_translate(
+        xml_translate_and_write(
             xml_file=self.reference_xml,
             outputfile=tested,
             xslt=self.mmd2iso_xslt,
@@ -89,7 +88,7 @@ class test_pymmdtools(unittest.TestCase):
         self.maxDiff = None
         tested = tempfile.mkstemp()[1]
         self.assertRaises(FileNotFoundError, 
-                            xml_translate, 
+                            xml_translate_and_write, 
                             self.not_a_file, 
                             tested, 
                             self.mmd2iso_xslt, 
@@ -100,12 +99,12 @@ class test_pymmdtools(unittest.TestCase):
     def test_xml_translate_assertRaises_FileNotFoundError_opt_xsdschema(self):
         self.maxDiff = None
         tested = tempfile.mkstemp()[1]
-        self.assertRaises(FileNotFoundError, xml_translate, self.reference_xml, tested, self.mmd2iso_xslt, True, self.not_a_file)
+        self.assertRaises(FileNotFoundError, xml_translate_and_write, self.reference_xml, tested, self.mmd2iso_xslt, True, self.not_a_file)
 
     def test_xml_translate_assertRaises_TypeError(self):
         self.maxDiff = None
         tested = tempfile.mkstemp()[1]
-        self.assertRaises(TypeError, xml_translate, self.reference_xml, tested, self.mmd2iso_xslt, True)
+        self.assertRaises(TypeError, xml_translate_and_write, self.reference_xml, tested, self.mmd2iso_xslt, True)
 
 if __name__=='__main__':
     unittest.main()

--- a/tests/test_xml_util.py
+++ b/tests/test_xml_util.py
@@ -96,6 +96,11 @@ class test_pymmdtools(unittest.TestCase):
                             self.reference_xsd) 
 
 
+    def test_xml_translate_assertRaises_FileNotFoundError_opt_xslt(self):
+        self.maxDiff = None
+        tested = tempfile.mkstemp()[1]
+        self.assertRaises(FileNotFoundError, xml_translate_and_write, self.reference_xml, tested, self.not_a_file, True, self.reference_xsd)
+
     def test_xml_translate_assertRaises_FileNotFoundError_opt_xsdschema(self):
         self.maxDiff = None
         tested = tempfile.mkstemp()[1]


### PR DESCRIPTION
…n, and do the translation and file writing in separate functions. Also changed some methods including input params.

**Summary**: refactored the xml_translate function but also changed input parameters to, e.g., `xsd_check`. does it mean the next version should be 1.1.0?

**Related issue**: #87 

**Suggested reviewer(s)**: @johtoblan 

**Reviewer checklist**:

- [ ] The headers of all files contain a reference to the repository license (i.e., "License: This file is part of py-mmd-tools, licensed under the Apache License 2.0 (https://www.apache.org/licenses/LICENSE-2.0)")
- [ ] 100% test coverage of new code - meaning:
    - [ ] The overall test coverage increased or remained the same as before
    - [ ] Every function is accompanied with a test suite
    - [ ] Tests are both positive (testing that the function work as intended with valid data) and negative (testing that the function behaves as expected with invalid data, e.g., that correct exceptions are thrown)
    - [ ] Functions with optional arguments have separate tests for all options
- [ ] Examples are supported by doctests
- [ ] All tests are passing
- [ ] All names (e.g., files, classes, functions, variables) are explicit
- [ ] Documentation (as docstrings) is complete and understandable

The checklist is based on the S-ENDA conventions and definition of done (see https://s-enda-documentation.readthedocs.io/en/latest/general_conventions.html). The above points are not necessarily relevant to all contributions. In that case, please add a short explanation to help the reviewer.
