### PR TITLE
#125: make time_coverage_start required

### DIFF
--- a/py_mmd_tools/mmd_elements.yaml
+++ b/py_mmd_tools/mmd_elements.yaml
@@ -84,10 +84,14 @@ temporal_extent:
     repetition: Comma separated list
     acdd: time_coverage_start
     separator: ','
+    maxOccurs: unbounded
+    minOccurs: '1'
   end_date:
     separator: ','
     repetition: Comma separated list
     acdd: time_coverage_end
+    maxOccurs: unbounded
+    minOccurs: '0'
 
 geographic_extent:
   maxOccurs: '1'

--- a/py_mmd_tools/nc_to_mmd.py
+++ b/py_mmd_tools/nc_to_mmd.py
@@ -34,7 +34,35 @@ from netCDF4 import Dataset
 
 
 def get_attr_info(key, convention, normalized):
-    """ToDo: Add docstring"""
+    """Get information about the MMD fields.
+
+    Input
+    =====
+    key: str
+        MMD element to check
+    convention: str
+        e.g., acdd or acdd_ext
+    normalized: dict
+        a normalized version of the mmd_elements dict (keys are, e.g.,
+        'personnel>organisation>acdd' or
+        'personnel>organisation>separator')
+
+    Returns
+    =======
+    required: int
+        if it is required
+    repetition: str ('yes' or 'no')
+        if repetition is allowed
+    repetition_str: str
+        a longer string representation for use in the DMH (basically
+        a comment)
+    separator: str
+        sign for separating elements that can be repeated (e.g., ','
+        or ';')
+    default:
+        a default value elements that are required but missing in the
+        netcdf file
+    """
     max_occurs_key = key.replace(convention, 'maxOccurs')
     if max_occurs_key in normalized.keys():
         max_occurs = normalized[max_occurs_key]


### PR DESCRIPTION
**Summary**: Solves issue with required `time_coverage_start` ending up in the "recommended" table in DMH. This can be checked by setting `PY_MMD_TOOLS_VERSION=issue125_time_coverage_start` in a `.env` file in your local copy of https://github.com/metno/data-management-handbook, then running `vagrant up`.

**Related issue**: closes #125 

**Suggested reviewer(s)**: @johtoblan 

**Reviewer checklist**:

- [ ] The headers of all files contain a reference to the repository license (i.e., "License: This file is part of py-mmd-tools, licensed under the Apache License 2.0 (https://www.apache.org/licenses/LICENSE-2.0)")
- [ ] 100% test coverage of new code - meaning:
    - [ ] The overall test coverage increased or remained the same as before
    - [ ] Every function is accompanied with a test suite
    - [ ] Tests are both positive (testing that the function work as intended with valid data) and negative (testing that the function behaves as expected with invalid data, e.g., that correct exceptions are thrown)
    - [ ] Functions with optional arguments have separate tests for all options
- [ ] Examples are supported by doctests
- [ ] All tests are passing
- [ ] All names (e.g., files, classes, functions, variables) are explicit
- [ ] Documentation (as docstrings) is complete and understandable

The checklist is based on the S-ENDA conventions and definition of done (see https://s-enda-documentation.readthedocs.io/en/latest/general_conventions.html). The above points are not necessarily relevant to all contributions. In that case, please add a short explanation to help the reviewer.
