### PR TITLE
Issue176 support python versions

### DIFF
--- a/.github/workflows/syntax.yml
+++ b/.github/workflows/syntax.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Python Setup
         uses: actions/setup-python@v1
         with:
-          python-version: 3.9
+          python-version: 3.10
           architecture: x64
       - name: Checkout Source
         uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,12 +8,15 @@ on:
 
 jobs:
   pyTestCov:
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
     runs-on: ubuntu-latest
     steps:
       - name: Python Setup
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: ${{ matrix.python-version }}
           architecture: x64
       - name: Checkout Source
         uses: actions/checkout@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Scientific/Engineering
     Topic :: Scientific/Engineering :: Atmospheric Science
@@ -29,7 +30,7 @@ project_urls =
 [options]
 include_package_data = True
 packages = py_mmd_tools
-install_requires = 
+install_requires =
     filehash
     jinja2
     lxml>=4.5


### PR DESCRIPTION
**Summary**: Issue176 support python versions

**Related issue**: #108 (coming up)

**Suggested reviewer(s)**: Johannes

**Reviewer checklist**:

Ensure that we now support Python versions 3.5..3.10 for both unit testing and CI.