### PR TITLE
Issue195 get license invalid url

### DIFF
--- a/py_mmd_tools/nc_to_mmd.py
+++ b/py_mmd_tools/nc_to_mmd.py
@@ -1044,8 +1044,8 @@ class Nc_to_mmd(object):
         old_version = False
         acdd_license = list(mmd_element['resource']['acdd'].keys())[0]
         acdd_license_id = list(mmd_element['identifier']['acdd_ext'].keys())[0]
-        acdd_license = getattr(ncin, acdd_license).split('(')
-        license_url = acdd_license[0]
+        license = getattr(ncin, acdd_license).split('(')
+        license_url = license[0]
         # validate url
         if not valid_url(license_url):
             # Try deprecated attribute name
@@ -1053,7 +1053,8 @@ class Nc_to_mmd(object):
                 license_url = ncin.license_resource
             if not valid_url(license_url):
                 self.missing_attributes['errors'].append(
-                    '%s is not a valid url' % license_url)
+                    '"%s" is not a valid url' % license_url)
+                return data
             else:
                 data = {'resource': license_url}
                 old_version = True
@@ -1061,8 +1062,8 @@ class Nc_to_mmd(object):
                     '"license_resource" is a deprecated attribute')
         else:
             data = {'resource': license_url}
-        if len(acdd_license) > 1:
-            data['identifier'] = acdd_license[1][0:-1]
+        if len(license) > 1:
+            data['identifier'] = license[1][0:-1]
         else:
             if acdd_license_id not in ncin.ncattrs():
                 self.missing_attributes['warnings'].append(

--- a/tests/test_nc_to_mmd.py
+++ b/tests/test_nc_to_mmd.py
@@ -328,7 +328,7 @@ class TestNC2MMD(unittest.TestCase):
         self.assertIsNone(value)
         self.assertEqual(
             md.missing_attributes["errors"][0],
-            'spdx.org/licenses/CC-BY-4.0 is not a valid url'
+            '"spdx.org/licenses/CC-BY-4.0" is not a valid url'
         )
 
     def test_license__with_acdd_ext(self):


### PR DESCRIPTION
**Summary**: closes #195 

**Related issue**: #195 

**Suggested reviewer(s)**:

**Reviewer checklist**:

- [ ] The headers of all files contain a reference to the repository license (i.e., "License: This file is part of py-mmd-tools, licensed under the Apache License 2.0 (https://www.apache.org/licenses/LICENSE-2.0)")
- [ ] 100% test coverage of new code - meaning:
    - [ ] The overall test coverage increased or remained the same as before
    - [ ] Every function is accompanied with a test suite
    - [ ] Tests are both positive (testing that the function work as intended with valid data) and negative (testing that the function behaves as expected with invalid data, e.g., that correct exceptions are thrown)
    - [ ] Functions with optional arguments have separate tests for all options
- [ ] Examples are supported by doctests
- [ ] All tests are passing
- [ ] All names (e.g., files, classes, functions, variables) are explicit
- [ ] Documentation (as docstrings) is complete and understandable

The checklist is based on the S-ENDA conventions and definition of done (see https://s-enda-documentation.readthedocs.io/en/latest/general_conventions.html). The above points are not necessarily relevant to all contributions. In that case, please add a short explanation to help the reviewer.
