### PR TITLE
#218: this should make it a little more flexible

### DIFF
--- a/py_mmd_tools/nc_to_mmd.py
+++ b/py_mmd_tools/nc_to_mmd.py
@@ -959,7 +959,7 @@ class Nc_to_mmd(object):
         """ Get related information stored in the netcdf attribute
         references.
         """
-        VALID_TYPES = [
+        VALID_REF_TYPES = [
             'Project home page',
             'Users guide',
             'Dataset landing page',
@@ -992,16 +992,23 @@ class Nc_to_mmd(object):
                     '%s must contain valid uris' % acdd_key
                 )
                 continue
-            type = ri[1][:-1]
-            if type not in VALID_TYPES:
+            ref_type = ri[1][:-1]
+            valid_ref_types = [vt.lower() for vt in VALID_REF_TYPES]
+            if ref_type.lower() not in valid_ref_types:
                 self.missing_attributes['errors'].append(
-                    'Reference types must follow a controlled '
-                    'vocabulary from MMD (see https://htmlpreview.'
-                    'github.io/?https://github.com/metno/mmd/blob/'
-                    'master/doc/mmd-specification.html#related-'
-                    'information-types).')
+                    'Reference types must follow a '
+                    'controlled vocabulary from MMD (see '
+                    'https://htmlpreview.github.io/?https://github.'
+                    'com/metno/mmd/blob/master/doc/mmd-specification.'
+                    'html#related-information-types).')
                 continue
-            ri = {'resource': uri, 'type': type}
+            # Need to make a new list of lists to use the filter
+            # function for comparison between ref_type and valid
+            # types from the MMD controlled vocabulary of related
+            # information types:
+            xx = [[ref_type, tt] for tt in VALID_REF_TYPES]
+            x = filter(lambda a: a[0].lower() == a[1].lower(), xx)
+            ri = {'resource': uri, 'type': list(x)[0][1]}
             ri['description'] = ""  # not easily available in acdd - needs to be discussed
             data.append(ri)
         return data


### PR DESCRIPTION
**Summary**: closes #218 

**Related issue**: #218 

**Suggested reviewer(s)**:

**Reviewer checklist**:

- [ ] The headers of all files contain a reference to the repository license (i.e., "License: This file is part of py-mmd-tools, licensed under the Apache License 2.0 (https://www.apache.org/licenses/LICENSE-2.0)")
- [ ] 100% test coverage of new code - meaning:
    - [ ] The overall test coverage increased or remained the same as before
    - [ ] Every function is accompanied with a test suite
    - [ ] Tests are both positive (testing that the function work as intended with valid data) and negative (testing that the function behaves as expected with invalid data, e.g., that correct exceptions are thrown)
    - [ ] Functions with optional arguments have separate tests for all options
- [ ] Examples are supported by doctests
- [ ] All tests are passing
- [ ] All names (e.g., files, classes, functions, variables) are explicit
- [ ] Documentation (as docstrings) is complete and understandable

The checklist is based on the S-ENDA conventions and definition of done (see https://s-enda-documentation.readthedocs.io/en/latest/general_conventions.html). The above points are not necessarily relevant to all contributions. In that case, please add a short explanation to help the reviewer.
