### PR TITLE
Update github actions

### DIFF
--- a/.github/workflows/syntax.yml
+++ b/.github/workflows/syntax.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Python Setup
-        uses: actions/setup-python@v1
+        uses: actions/setup-python
         with:
           python-version: '3.10'
           architecture: x64
       - name: Checkout Source
-        uses: actions/checkout@v2
+        uses: actions/checkout
       - name: Install flake8
         run: pip install flake8
       - name: Syntax Error Check

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Python Setup
-        uses: actions/setup-python@v2
+        uses: actions/setup-python
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
       - name: Checkout Source
-        uses: actions/checkout@v2
+        uses: actions/checkout
       - name: Install Dependencies
         run: |
           pip install --upgrade pip
@@ -32,4 +32,4 @@ jobs:
           git clone https://github.com/metno/mmd $MMD_PATH
           python -m pytest -v --cov=py_mmd_tools --cov=script --timeout=120
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action


### PR DESCRIPTION
**Summary**: Github actions/python-setup@v2 "ubuntu-latest" now refers to Ubuntu-22.04, there is no python 3.6 for this version.

**Related issue**: 

**Suggested reviewer(s)**:

**Reviewer checklist**:

- [ ] The headers of all files contain a reference to the repository license (i.e., "License: This file is part of py-mmd-tools, licensed under the Apache License 2.0 (https://www.apache.org/licenses/LICENSE-2.0)")
- [ ] 100% test coverage of new code - meaning:
    - [ ] The overall test coverage increased or remained the same as before
    - [ ] Every function is accompanied with a test suite
    - [ ] Tests are both positive (testing that the function work as intended with valid data) and negative (testing that the function behaves as expected with invalid data, e.g., that correct exceptions are thrown)
    - [ ] Functions with optional arguments have separate tests for all options
- [ ] Examples are supported by doctests
- [ ] All tests are passing
- [ ] All names (e.g., files, classes, functions, variables) are explicit
- [ ] Documentation (as docstrings) is complete and understandable

The checklist is based on the S-ENDA conventions and definition of done (see https://s-enda-documentation.readthedocs.io/en/latest/general_conventions.html). The above points are not necessarily relevant to all contributions. In that case, please add a short explanation to help the reviewer.
