### PR TITLE
#232: require both input file and opendap url unless the user only wa…

### DIFF
--- a/py_mmd_tools/nc_to_mmd.py
+++ b/py_mmd_tools/nc_to_mmd.py
@@ -131,6 +131,8 @@ class Nc_to_mmd(object):
             raise ValueError(
                 "The opendap_url and output_file input parameters "
                 "must be provided if check_only is False")
+        if not os.path.isabs(netcdf_file):
+            raise ValueError("The path to the NetCDF-CF file must be absolute.")
         super(Nc_to_mmd, self).__init__()
         self.output_file = output_file
         self.netcdf_file = netcdf_file

--- a/py_mmd_tools/nc_to_mmd.py
+++ b/py_mmd_tools/nc_to_mmd.py
@@ -115,21 +115,27 @@ class Nc_to_mmd(object):
     ACDD_NAMING_AUTH = 'naming_authority'
     ACDD_ID_INVALID_CHARS = ['\\', '/', ':', ' ']
 
-    def __init__(self, netcdf_product, output_file=None, check_only=False):
+    def __init__(self, netcdf_file, opendap_url=None, output_file=None, check_only=False):
         """Class for creating an MMD XML file based on the discovery
         metadata provided in the global attributes of NetCDF files that
         are compliant with the CF-conventions and ACDD.
 
         Args:
-            output_file (pathlib): Output path for mmd.
-            netcdf_product (str): Input NetCDF file (nc file or OPeNDAP
-                url).
+            output_file : str
+                Output path for the resulting mmd xml file
+            netcdf_file : str
+                Input NetCDF file
+            opendap_url : str
+                OPeNDAP url
         """
-        if output_file is None and check_only is False:
-            raise ValueError('output_filename must be provided if check_only is False')
+        if (output_file is None or opendap_url is None) and check_only is False:
+            raise ValueError(
+                "The opendap_url and output_file input parameters "
+                "must be provided if check_only is False")
         super(Nc_to_mmd, self).__init__()
         self.output_file = output_file
-        self.netcdf_product = netcdf_product
+        self.netcdf_file = netcdf_file
+        self.opendap_url = opendap_url
         self.check_only = check_only
         self.missing_attributes = {
             'errors': [],
@@ -147,7 +153,7 @@ class Nc_to_mmd(object):
             raise ValueError('Instrument or Platform group were not initialised')
 
         # Open netcdf file for reading
-        with self.read_nc_file(self.netcdf_product) as ncin:
+        with self.read_nc_file(self.netcdf_file) as ncin:
             self.check_attributes_not_empty(ncin)
 
         return
@@ -156,9 +162,9 @@ class Nc_to_mmd(object):
         """ Open netcdf dataset, appending #fillmismatch if necessary
         """
         try:
-            ncin = Dataset(self.netcdf_product)
+            ncin = Dataset(self.netcdf_file)
         except OSError:
-            ncin = Dataset(self.netcdf_product+'#fillmismatch')
+            ncin = Dataset(self.netcdf_file+'#fillmismatch')
 
         return ncin
 
@@ -1019,7 +1025,7 @@ class Nc_to_mmd(object):
         for attr in ncin.ncattrs():
             if ncin.getncattr(attr) == "":
                 raise ValueError("%s: Global attribute %s is empty - please correct." % (
-                    self.netcdf_product, attr))
+                    self.netcdf_file, attr))
 
     def check_conventions(self, ncin):
         """ Check that the Conventions attribute is present, and
@@ -1173,7 +1179,7 @@ class Nc_to_mmd(object):
         geographic_extent_rectangle = kwargs.pop('geographic_extent_rectangle', '')
 
         # Open netcdf file for reading
-        ncin = self.read_nc_file(self.netcdf_product)
+        ncin = self.read_nc_file(self.netcdf_file)
 
         self.check_attributes_not_empty(ncin)
 
@@ -1264,33 +1270,23 @@ class Nc_to_mmd(object):
 
         # Data access should not be read from the netCDF-CF file
         mmd_yaml.pop('data_access')
-        # Add OPeNDAP data_access if "netcdf_product" is OPeNDAP url
-        rm_file_for_checksum_calculation = False
-        if 'dodsC' in self.netcdf_product:
+        # Add OPeNDAP data_access if opendap_url is not None
+        if self.opendap_url is not None:
             self.metadata['data_access'] = self.get_data_access_dict(ncin, **kwargs)
-            resource = ''
-            for access in self.metadata['data_access']:
-                if access['type'] == 'HTTP':
-                    resource = access['resource']
-            logging.info('Downloading NetCDF file to calculate checksum...')
-            file_for_checksum_calculation = wget.download(resource)
-            rm_file_for_checksum_calculation = True
         else:
             self.metadata['data_access'] = []
-            file_for_checksum_calculation = self.netcdf_product
 
-        file_size = pathlib.Path(file_for_checksum_calculation).stat().st_size / (1024 * 1024)
+        file_size = pathlib.Path(self.netcdf_file).stat().st_size / (1024 * 1024)
 
         for key in mmd_yaml:
             self.metadata[key] = self.get_acdd_metadata(mmd_yaml[key], ncin, key)
 
         # Set storage_information
-
-        file_location = self.netcdf_product
+        file_location = self.netcdf_file
 
         self.metadata['storage_information'] = {
-            'file_name': os.path.basename(self.netcdf_product),
-            'file_location': file_location,
+            'file_name': os.path.basename(self.netcdf_file),
+            'file_location': os.path.dirname(self.netcdf_file),
             'file_format': 'NetCDF-CF',
             'file_size': '%.2f'%file_size,
             'file_size_unit': 'MB',
@@ -1298,14 +1294,11 @@ class Nc_to_mmd(object):
 
         if checksum_calculation:
             hasher = FileHash('md5', chunk_size=1048576)
-            fchecksum = hasher.hash_file(file_for_checksum_calculation)
+            fchecksum = hasher.hash_file(self.netcdf_file)
 
             self.metadata['storage_information']['checksum'] = fchecksum
             self.metadata['storage_information']['checksum_type'] = '%ssum' % \
                                                                     hasher.hash_algorithm
-
-        if rm_file_for_checksum_calculation:
-            os.remove(file_for_checksum_calculation)
 
         self.check_conventions(ncin)
         self.check_feature_type(ncin)
@@ -1329,13 +1322,26 @@ class Nc_to_mmd(object):
         req_ok = True
         # If running in check only mode, exit now
         # and return whether the required elements are present
-        if self.check_only:
-            return req_ok, msg
-
-        with open(self.output_file, 'w') as fh:
-            fh.write(out_doc)
+        if not self.check_only:
+            with open(self.output_file, 'w') as fh:
+                fh.write(out_doc)
+        
+        return req_ok, msg
 
     def get_data_access_dict(self, ncin, add_wms_data_access=False, add_http_data_access=True):
+        """ Return a dictionary with data access information. OGC WMS
+        urls can only be provided for gridded datasets.
+
+        Parameters
+        ----------
+        ncin : netCDF4._netCDF4.Dataset
+            An open NetCDF dataset
+        add_wms_data_access : Boolean
+            Adds OGC WMS data access if True. This is False by
+            default, since only gridded datasets can have WMS access.
+        add_http_data_access : Boolean
+            Adds HTTP data access link if True (default).
+        """
         all_netcdf_variables = []
         for var in ncin.variables:
             if 'standard_name' in ncin.variables[var].ncattrs():
@@ -1343,7 +1349,7 @@ class Nc_to_mmd(object):
         data_accesses = [{
             'type': 'OPeNDAP',
             'description': 'Open-source Project for a Network Data Access Protocol',
-            'resource': self.netcdf_product,
+            'resource': self.opendap_url,
         }]
 
         access_list = []
@@ -1352,11 +1358,11 @@ class Nc_to_mmd(object):
         if add_wms_data_access:  # and 2D dataset...?
             access_list.append('OGC WMS')
             _desc.append('OGC Web Mapping Service, URI to GetCapabilities Document.')
-            _res.append(self.netcdf_product.replace('dodsC', 'wms'))
+            _res.append(self.opendap_url.replace('dodsC', 'wms'))
         if add_http_data_access:
             access_list.append('HTTP')
             _desc.append('Direct download of file')
-            _res.append(self.netcdf_product.replace('dodsC', 'fileServer'))
+            _res.append(self.opendap_url.replace('dodsC', 'fileServer'))
 
         for prot_type, desc, res in zip(access_list, _desc, _res):
             data_access = {

--- a/py_mmd_tools/nc_to_mmd.py
+++ b/py_mmd_tools/nc_to_mmd.py
@@ -1339,6 +1339,14 @@ class Nc_to_mmd(object):
         add_http_data_access : Boolean
             Adds HTTP data access link if True (default).
         """
+        # Check that the OPeNDAP url is accessible
+        try:
+            ds = Dataset(self.opendap_url)
+        except OSError as oe:
+            self.missing_attributes['errors'].append(str(oe))
+            return []
+        else:
+            ds.close()
         all_netcdf_variables = []
         for var in ncin.variables:
             if 'standard_name' in ncin.variables[var].ncattrs():

--- a/py_mmd_tools/nc_to_mmd.py
+++ b/py_mmd_tools/nc_to_mmd.py
@@ -20,7 +20,6 @@ import warnings
 import yaml
 import jinja2
 import logging
-import wget
 import shapely.wkt
 
 from filehash import FileHash
@@ -1282,8 +1281,6 @@ class Nc_to_mmd(object):
             self.metadata[key] = self.get_acdd_metadata(mmd_yaml[key], ncin, key)
 
         # Set storage_information
-        file_location = self.netcdf_file
-
         self.metadata['storage_information'] = {
             'file_name': os.path.basename(self.netcdf_file),
             'file_location': os.path.dirname(self.netcdf_file),
@@ -1325,7 +1322,7 @@ class Nc_to_mmd(object):
         if not self.check_only:
             with open(self.output_file, 'w') as fh:
                 fh.write(out_doc)
-        
+
         return req_ok, msg
 
     def get_data_access_dict(self, ncin, add_wms_data_access=False, add_http_data_access=True):

--- a/py_mmd_tools/script/nc2mmd.py
+++ b/py_mmd_tools/script/nc2mmd.py
@@ -18,6 +18,7 @@ Example:
 """
 
 import argparse
+import os
 import pathlib
 
 from py_mmd_tools import nc_to_mmd
@@ -32,7 +33,16 @@ def create_parser():
     # Add to parse a whole server?
     parser.add_argument(
         '-i', '--input', type=str,
-        help='Input file, folder or OPeNDAP url.'
+        help='Input file or folder.'
+    )
+    parser.add_argument(
+        '--dry-run', action='store_true',
+        help='Dry-run to check the netcdf metadata content.'
+    )
+    parser.add_argument(
+        '-u', '--url', type=str,
+        help = 'OPeNDAP url. If multiple files shall be processed, '
+               'this should be their base url.'
     )
     parser.add_argument(
         '-o', '--output_dir', type=pathlib.Path,
@@ -40,7 +50,7 @@ def create_parser():
     )
     parser.add_argument(
         '-w', '--add_wms_data_access', action='store_true',
-        help='Optional add wms in data_access.'
+        help='Add wms data access (optional).'
     )
     parser.add_argument(
         '-c', '--checksum_calculation',  action='store_true',
@@ -56,23 +66,35 @@ def create_parser():
 
 def main(args=None):
     """Run tool to create MMD xml file from input netCDF-CF file(s)"""
+    if not args.dry_run:
+        if args.url is None:
+            raise ValueError('OPeNDAP url must be provided')
+        if args.output_dir is None:
+            raise ValueError('MMD XML output directory must be provided')
 
+    assume_base_url = False
     if pathlib.Path(args.input).is_dir():
         # Directory containing nc files
         inputfiles = pathlib.Path(args.input).glob('*.nc')
-    elif 'dodsC' in args.input:
-        # A remote OPeNDAP url
-        inputfiles = [args.input]
+        assume_base_url = True
     elif pathlib.Path(args.input).is_file():
         # Single nc file
         inputfiles = [args.input]
     else:
         raise ValueError(f'Invalid input: {args.input}')
 
+    url = None  # dry-run option
     for file in inputfiles:
-        outfile = (args.output_dir / pathlib.Path(file).stem).with_suffix('.xml')
-        md = nc_to_mmd.Nc_to_mmd(str(file), output_file=outfile)
-        md.to_mmd(
+        if not args.dry_run:
+            if assume_base_url:
+                url = os.path.join(args.url, file)
+            else:
+                url = args.url
+            outfile = (args.output_dir / pathlib.Path(file).stem).with_suffix('.xml')
+            md = nc_to_mmd.Nc_to_mmd(str(file), opendap_url=url, output_file=outfile)
+        else:
+            md = nc_to_mmd.Nc_to_mmd(str(file), check_only=True)
+        req_ok, msg = md.to_mmd(
             add_wms_data_access=args.add_wms_data_access,
             checksum_calculation=args.checksum_calculation,
             collection=args.collection

--- a/py_mmd_tools/script/nc2mmd.py
+++ b/py_mmd_tools/script/nc2mmd.py
@@ -72,11 +72,13 @@ def main(args=None):
         if args.output_dir is None:
             raise ValueError('MMD XML output directory must be provided')
 
-    assume_base_url = False
+    assume_same_url_basename = False
     if pathlib.Path(args.input).is_dir():
         # Directory containing nc files
         inputfiles = pathlib.Path(args.input).glob('*.nc')
-        assume_base_url = True
+        # If the input is a directory, we need to assume that the
+        # file and url basenames are the same
+        assume_same_url_basename = True
     elif pathlib.Path(args.input).is_file():
         # Single nc file
         inputfiles = [args.input]
@@ -86,7 +88,7 @@ def main(args=None):
     url = None  # dry-run option
     for file in inputfiles:
         if not args.dry_run:
-            if assume_base_url:
+            if assume_same_url_basename:
                 url = os.path.join(args.url, file)
             else:
                 url = args.url

--- a/py_mmd_tools/script/nc2mmd.py
+++ b/py_mmd_tools/script/nc2mmd.py
@@ -41,8 +41,8 @@ def create_parser():
     )
     parser.add_argument(
         '-u', '--url', type=str,
-        help = 'OPeNDAP url. If multiple files shall be processed, '
-               'this should be their base url.'
+        help='OPeNDAP url. If multiple files shall be processed, '
+             'this should be their base url.'
     )
     parser.add_argument(
         '-o', '--output_dir', type=pathlib.Path,

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 markers =
     script: Script tests
+    py_mmd_tools: Main package tools

--- a/tests/test_check_nc.py
+++ b/tests/test_check_nc.py
@@ -68,7 +68,6 @@ def test_main_thredds(dataDir, monkeypatch):
         '-i', test_in,
     ])
     with monkeypatch.context() as mp:
-        mp.setattr('py_mmd_tools.nc_to_mmd.wget.download', lambda *a: test_in)
         mp.setattr('py_mmd_tools.nc_to_mmd.os.remove', lambda *a: None)
         res = main(parsed)
     assert res is None

--- a/tests/test_nc2mmd_script.py
+++ b/tests/test_nc2mmd_script.py
@@ -51,10 +51,9 @@ def test_main_localfile_missing_opendap(dataDir):
 def test_main_localfile_missing_output_dir(dataDir):
     parser = create_parser()
     test_in = os.path.join(dataDir, 'reference_nc.nc')
-    out_dir = tempfile.mkdtemp()
     parsed = parser.parse_args([
         '-i', test_in,
-        '-u', 'https://thredds.met.no/thredds/dodsC/reference_nc.nc', 
+        '-u', 'https://thredds.met.no/thredds/dodsC/reference_nc.nc',
     ])
     with pytest.raises(ValueError) as ve:
         main(parsed)
@@ -68,7 +67,7 @@ def test_main_localfile_specify_collection(dataDir):
     out_dir = tempfile.mkdtemp()
     parsed = parser.parse_args([
         '-i', test_in,
-        '-u', 'https://thredds.met.no/thredds/dodsC/reference_nc.nc', 
+        '-u', 'https://thredds.met.no/thredds/dodsC/reference_nc.nc',
         '-o', out_dir,
         '--collection', 'ADC'
     ])
@@ -85,12 +84,11 @@ def test_main_thredds(dataDir, monkeypatch):
     out_dir = tempfile.mkdtemp()
     parsed = parser.parse_args([
         '-i', test_in,
-        '-u', 'https://thredds.met.no/thredds/dodsC/reference_nc.nc', 
+        '-u', 'https://thredds.met.no/thredds/dodsC/reference_nc.nc',
         '-o', out_dir,
         '-w'
     ])
     with monkeypatch.context() as mp:
-        mp.setattr('py_mmd_tools.nc_to_mmd.wget.download', lambda *a: test_in)
         mp.setattr('py_mmd_tools.nc_to_mmd.os.remove', lambda *a: None)
         main(parsed)
     assert os.path.isfile(os.path.join(out_dir, 'reference_nc.xml'))
@@ -135,7 +133,6 @@ def test_dry_run(dataDir):
     """Test running the script with the dry-run option."""
     parser = create_parser()
     test_in = os.path.join(dataDir, 'reference_nc.nc')
-    out_dir = tempfile.mkdtemp()
     parsed = parser.parse_args([
         '-i', test_in,
         '--dry-run'

--- a/tests/test_nc2mmd_script.py
+++ b/tests/test_nc2mmd_script.py
@@ -175,7 +175,7 @@ def test_invalid_opendap_url(dataDir):
     ])
     with pytest.raises(AttributeError) as ae:
         main(parsed)
-    assert 'Malformed' in str(ae.value)
+    assert 'NetCDF:' in str(ae.value)
 
 
 @pytest.mark.script

--- a/tests/test_nc2mmd_script.py
+++ b/tests/test_nc2mmd_script.py
@@ -13,23 +13,44 @@ import tempfile
 
 import pytest
 
+from netCDF4 import Dataset
+
 from py_mmd_tools.script.nc2mmd import create_parser
 from py_mmd_tools.script.nc2mmd import main
 
 
+class MockDataset:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def close(self):
+        pass
+
+
+def patchedDataset(url, *args, **kwargs):
+    if args[0] == url:
+        return MockDataset(*args, **kwargs)
+    else:
+        return Dataset(*args, **kwargs)
+
+
 @pytest.mark.script
-def test_main_localfile(dataDir):
+def test_main_localfile(dataDir, monkeypatch):
     """Test nc2mmd.py with a local file"""
     parser = create_parser()
     test_in = os.path.join(dataDir, 'reference_nc.nc')
     out_dir = tempfile.mkdtemp()
+    url = 'https://thredds.met.no/thredds/dodsC/reference_nc.nc'
     parsed = parser.parse_args([
         '-i', test_in,
-        '--url', 'https://thredds.met.no/thredds/dodsC/reference_nc.nc',
+        '--url', url,
         '-o', out_dir
     ])
-    main(parsed)
-    assert os.path.isfile(os.path.join(out_dir, 'reference_nc.xml'))
+    with monkeypatch.context() as mp:
+        mp.setattr("py_mmd_tools.nc_to_mmd.Dataset",
+                   lambda *args, **kwargs: patchedDataset(url, *args, **kwargs))
+        main(parsed)
+        assert os.path.isfile(os.path.join(out_dir, 'reference_nc.xml'))
     shutil.rmtree(out_dir)
 
 
@@ -51,9 +72,10 @@ def test_main_localfile_missing_opendap(dataDir):
 def test_main_localfile_missing_output_dir(dataDir):
     parser = create_parser()
     test_in = os.path.join(dataDir, 'reference_nc.nc')
+    url = 'https://thredds.met.no/thredds/dodsC/reference_nc.nc'
     parsed = parser.parse_args([
         '-i', test_in,
-        '-u', 'https://thredds.met.no/thredds/dodsC/reference_nc.nc',
+        '-u', url,
     ])
     with pytest.raises(ValueError) as ve:
         main(parsed)
@@ -61,18 +83,22 @@ def test_main_localfile_missing_output_dir(dataDir):
 
 
 @pytest.mark.script
-def test_main_localfile_specify_collection(dataDir):
+def test_main_localfile_specify_collection(dataDir, monkeypatch):
     parser = create_parser()
     test_in = os.path.join(dataDir, 'reference_nc.nc')
     out_dir = tempfile.mkdtemp()
+    url = 'https://thredds.met.no/thredds/dodsC/reference_nc.nc'
     parsed = parser.parse_args([
         '-i', test_in,
-        '-u', 'https://thredds.met.no/thredds/dodsC/reference_nc.nc',
+        '-u', url,
         '-o', out_dir,
         '--collection', 'ADC'
     ])
-    main(parsed)
-    assert os.path.isfile(os.path.join(out_dir, 'reference_nc.xml'))
+    with monkeypatch.context() as mp:
+        mp.setattr("py_mmd_tools.nc_to_mmd.Dataset",
+                   lambda *args, **kwargs: patchedDataset(url, *args, **kwargs))
+        main(parsed)
+        assert os.path.isfile(os.path.join(out_dir, 'reference_nc.xml'))
     shutil.rmtree(out_dir)
 
 
@@ -82,32 +108,39 @@ def test_main_thredds(dataDir, monkeypatch):
     parser = create_parser()
     test_in = os.path.join(dataDir, 'reference_nc.nc')
     out_dir = tempfile.mkdtemp()
+    url = 'https://thredds.met.no/thredds/dodsC/reference_nc.nc'
     parsed = parser.parse_args([
         '-i', test_in,
-        '-u', 'https://thredds.met.no/thredds/dodsC/reference_nc.nc',
+        '-u', url,
         '-o', out_dir,
         '-w'
     ])
     with monkeypatch.context() as mp:
         mp.setattr('py_mmd_tools.nc_to_mmd.os.remove', lambda *a: None)
+        mp.setattr("py_mmd_tools.nc_to_mmd.Dataset",
+                   lambda *args, **kwargs: patchedDataset(url, *args, **kwargs))
         main(parsed)
     assert os.path.isfile(os.path.join(out_dir, 'reference_nc.xml'))
     shutil.rmtree(out_dir)
 
 
 @pytest.mark.script
-def test_with_folder(dataDir):
+def test_with_folder(dataDir, monkeypatch):
     """Test nc2mmd.py with a folder as input"""
     parser = create_parser()
     in_dir = tempfile.mkdtemp()
     shutil.copy(os.path.join(dataDir, 'reference_nc.nc'), in_dir)
     out_dir = tempfile.mkdtemp()
+    url = 'https://thredds.met.no/thredds/dodsC'
     parsed = parser.parse_args([
         '-i', in_dir,
-        '-u', 'https://thredds.met.no/thredds/dodsC',
+        '-u', url,
         '-o', out_dir
     ])
-    main(parsed)
+    with monkeypatch.context() as mp:
+        mp.setattr("py_mmd_tools.nc_to_mmd.Dataset",
+                   lambda *args, **kwargs: patchedDataset(url, *args, **kwargs))
+        main(parsed)
     assert os.path.isfile(os.path.join(out_dir, 'reference_nc.xml'))
     shutil.rmtree(out_dir)
     shutil.rmtree(in_dir)
@@ -126,6 +159,23 @@ def test_invalid():
     with pytest.raises(ValueError) as ve:
         main(parsed)
     assert 'Invalid input' in str(ve.value)
+
+
+@pytest.mark.script
+def test_invalid_opendap_url(dataDir):
+    """Test that the script raises ValueError if input is wrong"""
+    parser = create_parser()
+    test_in = os.path.join(dataDir, 'reference_nc.nc')
+    out_dir = tempfile.mkdtemp()
+    url = 'https://thredds.met.no/thredds/dodsC/reference_nc.nc'
+    parsed = parser.parse_args([
+        '-i', test_in,
+        '-u', url,
+        '-o', out_dir
+    ])
+    with pytest.raises(AttributeError) as ae:
+        main(parsed)
+    assert 'Malformed' in str(ae.value)
 
 
 @pytest.mark.script

--- a/tests/test_nc_to_mmd.py
+++ b/tests/test_nc_to_mmd.py
@@ -304,7 +304,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.reference_nc, check_only=True)
-        ncin = Dataset(md.netcdf_product, "w", diskless=True)
+        ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.license = "CC-BY-4.0"
         ncin.license_resource = "http://spdx.org/licenses/CC-BY-4.0"
         value = md.get_license(mmd_yaml['use_constraint'], ncin)
@@ -322,7 +322,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.reference_nc, check_only=True)
-        ncin = Dataset(md.netcdf_product, "w", diskless=True)
+        ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.license = "spdx.org/licenses/CC-BY-4.0"
         value = md.get_license(mmd_yaml['use_constraint'], ncin)
         self.assertIsNone(value)
@@ -336,7 +336,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.reference_nc, check_only=True)
-        ncin = Dataset(md.netcdf_product, "w", diskless=True)
+        ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.license = "http://spdx.org/licenses/CC-BY-4.0"
         ncin.license_identifier = "CC-BY-4.0"
         value = md.get_license(mmd_yaml['use_constraint'], ncin)
@@ -348,7 +348,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.reference_nc, check_only=True)
-        ncin = Dataset(md.netcdf_product, "w", diskless=True)
+        ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.license = "http://spdx.org/licenses/CC-BY-4.0"
         value = md.get_license(mmd_yaml['use_constraint'], ncin)
         self.assertEqual(value['resource'], 'http://spdx.org/licenses/CC-BY-4.0')
@@ -362,7 +362,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.reference_nc, check_only=True)
-        ncin = Dataset(md.netcdf_product, "w", diskless=True)
+        ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.license = "http://spdx.org/licenses/CC-BY-4.0(CC-BY-4.0)"
         value = md.get_license(mmd_yaml['use_constraint'], ncin)
         self.assertEqual(value['resource'], 'http://spdx.org/licenses/CC-BY-4.0')
@@ -373,7 +373,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.reference_nc, check_only=True)
-        ncin = Dataset(md.netcdf_product, "w", diskless=True)
+        ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.license = "http://spdx.org/licenses/CC-BY-4.0 (CC-BY-4.0)"
         value = md.get_license(mmd_yaml['use_constraint'], ncin)
         self.assertEqual(value['resource'], 'http://spdx.org/licenses/CC-BY-4.0')
@@ -402,7 +402,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
-        ncin = Dataset(md.netcdf_product)
+        ncin = Dataset(md.netcdf_file)
         value = md.get_acdd_metadata(
             mmd_yaml['metadata_status'],
             ncin, 'metadata_status'
@@ -418,7 +418,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
-        ncin = Dataset(md.netcdf_product)
+        ncin = Dataset(md.netcdf_file)
         with self.assertRaises(ValueError) as e:
             md.get_acdd_metadata(
                 mmd_yaml['metadata_identifier'],
@@ -435,7 +435,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
-        ncin = Dataset(md.netcdf_product)
+        ncin = Dataset(md.netcdf_file)
         value = md.get_metadata_updates(mmd_yaml['last_metadata_update'], ncin)
         self.assertEqual(value['update'][0]['type'], 'Created')
 
@@ -447,7 +447,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.fail_nc, check_only=True)
-        ncin = Dataset(md.netcdf_product, "w", diskless=True)
+        ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.geospatial_bounds = ""
         md.get_geographic_extent_polygon(
             mmd_yaml['geographic_extent']['polygon'], ncin
@@ -463,7 +463,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
-        ncin = Dataset(md.netcdf_product)
+        ncin = Dataset(md.netcdf_file)
         value = md.get_geographic_extent_polygon(
             mmd_yaml['geographic_extent']['polygon'], ncin
         )
@@ -476,7 +476,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd('tests/data/reference_nc_missing_attrs.nc', check_only=True)
-        ncin = Dataset(md.netcdf_product)
+        ncin = Dataset(md.netcdf_file)
         value = md.get_acdd_metadata(mmd_yaml['geographic_extent'], ncin, 'geographic_extent')
         self.assertEqual(value['rectangle']['north'], None)
         value = md.get_data_centers(mmd_yaml['data_center'], ncin)
@@ -497,7 +497,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
-        ncin = Dataset(md.netcdf_product, "w", diskless=True)
+        ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.geospatial_lat_max = "60.158733f; // float"
         ncin.geospatial_lat_min = "59.78492f; // float"
         ncin.geospatial_lon_max = "10.944986f; // float"
@@ -555,7 +555,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
-        ncin = Dataset(md.netcdf_product)
+        ncin = Dataset(md.netcdf_file)
         value = md.get_abstracts(mmd_yaml['abstract'], ncin)
         self.assertEqual(type(value), list)
         self.assertTrue('lang' in value[0].keys())
@@ -567,7 +567,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
-        ncin = Dataset(md.netcdf_product)
+        ncin = Dataset(md.netcdf_file)
         value = md.get_titles(mmd_yaml['title'], ncin)
         self.assertEqual(type(value), list)
         self.assertTrue('lang' in value[0].keys())
@@ -584,7 +584,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd('tests/data/reference_nc_id_missing.nc', check_only=True)
-        ncin = Dataset(md.netcdf_product)
+        ncin = Dataset(md.netcdf_file)
         value = md.get_titles(mmd_yaml['title'], ncin)
         self.assertEqual(type(value), list)
         self.assertTrue('lang' in value[0].keys())
@@ -596,7 +596,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
-        ncin = Dataset(md.netcdf_product)
+        ncin = Dataset(md.netcdf_file)
         value = md.get_data_centers(mmd_yaml['data_center'], ncin)
         self.assertEqual(type(value), list)
         self.assertEqual(value, [{
@@ -611,7 +611,7 @@ class TestNC2MMD(unittest.TestCase):
         """ToDo: Add docstring"""
         yaml.load(resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader)
         md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
-        Dataset(md.netcdf_product)
+        Dataset(md.netcdf_file)
         value = None
         self.assertEqual(value, None)
 
@@ -621,7 +621,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
-        ncin = Dataset(md.netcdf_product)
+        ncin = Dataset(md.netcdf_file)
         value = md.get_acdd_metadata(
             mmd_yaml['dataset_production_status'], ncin, 'dataset_production_status'
         )
@@ -635,7 +635,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
-        ncin = Dataset(md.netcdf_product)
+        ncin = Dataset(md.netcdf_file)
         value = md.get_acdd_metadata(
             mmd_yaml['alternate_identifier'], ncin, 'alternate_identifier'
         )
@@ -650,7 +650,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd('tests/data/reference_nc_with_altID.nc', check_only=True)
-        ncin = Dataset(md.netcdf_product)
+        ncin = Dataset(md.netcdf_file)
         value = md.get_acdd_metadata(
             mmd_yaml['alternate_identifier'], ncin, 'alternate_identifier'
         )
@@ -665,7 +665,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd('tests/data/reference_nc_with_altID_multiple.nc', check_only=True)
-        ncin = Dataset(md.netcdf_product)
+        ncin = Dataset(md.netcdf_file)
         value = md.get_acdd_metadata(
             mmd_yaml['alternate_identifier'], ncin, 'alternate_identifier'
         )
@@ -679,7 +679,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
-        ncin = Dataset(md.netcdf_product)
+        ncin = Dataset(md.netcdf_file)
         value = md.get_acdd_metadata(mmd_yaml['metadata_status'], ncin, 'metadata_status')
         self.assertEqual(value, 'Active')
 
@@ -689,7 +689,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
-        ncin = Dataset(md.netcdf_product)
+        ncin = Dataset(md.netcdf_file)
         value = md.get_metadata_updates(mmd_yaml['last_metadata_update'], ncin)
         self.assertEqual(value['update'][0]['datetime'], '2020-11-27T14:05:56Z')
 
@@ -699,7 +699,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd('tests/data/reference_nc_missing_attrs.nc', check_only=True)
-        ncin = Dataset(md.netcdf_product)
+        ncin = Dataset(md.netcdf_file)
         value = md.get_personnel(mmd_yaml['personnel'], ncin)
         self.assertEqual(value[0]['role'], 'Investigator')
         self.assertEqual(value[0]['name'], 'Not available')
@@ -712,7 +712,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd('tests/data/reference_nc_missing_attrs.nc', check_only=True)
-        ncin = Dataset(md.netcdf_product)
+        ncin = Dataset(md.netcdf_file)
         value = md.get_temporal_extents(mmd_yaml['temporal_extent'], ncin)
         self.assertEqual(value, [])
         self.assertEqual(
@@ -770,7 +770,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd('tests/data/reference_nc_attrs_multiple.nc', check_only=True)
-        ncin = Dataset(md.netcdf_product)
+        ncin = Dataset(md.netcdf_file)
         value = md.get_temporal_extents(mmd_yaml['temporal_extent'], ncin)
         self.assertEqual(value[0]['start_date'], '2020-11-27T13:40:02.019817Z')
         self.assertEqual(value[1]['start_date'], '2020-12-27T13:40:02.019817Z')
@@ -786,7 +786,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd('tests/data/reference_nc_attrs_multiple.nc', check_only=True)
-        ncin = Dataset(md.netcdf_product, "w", diskless=True)
+        ncin = Dataset(md.netcdf_file, "w", diskless=True)
 
         valid_start = '2020-11-27T13:40:02.019817Z'
         invalid_start = '2020-13-27T13:40:02.019817'  # month outside [0,12]
@@ -850,7 +850,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
-        ncin = Dataset(md.netcdf_product)
+        ncin = Dataset(md.netcdf_file)
         value = md.get_temporal_extents(mmd_yaml['temporal_extent'], ncin)
         self.assertEqual(value[0]['start_date'], '2020-11-27T13:40:02.019817Z')
         self.assertEqual(value[0]['end_date'], '2020-11-27T13:51:24.401505Z')
@@ -866,7 +866,7 @@ class TestNC2MMD(unittest.TestCase):
             'tests/data/reference_nc_attrs_multiple_mixed_creator.nc',
             check_only=True
         )
-        ncin = Dataset(md.netcdf_product)
+        ncin = Dataset(md.netcdf_file)
         md.get_personnel(mmd_yaml['personnel'], ncin)
         self.assertEqual(
             md.missing_attributes['errors'][0],
@@ -881,7 +881,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd('tests/data/reference_nc_attrs_multiple.nc', check_only=True)
-        ncin = Dataset(md.netcdf_product)
+        ncin = Dataset(md.netcdf_file)
         value = md.get_personnel(mmd_yaml['personnel'], ncin)
         self.assertEqual(value[0]['name'], 'Trygve')
         self.assertEqual(value[1]['name'], 'Nina')
@@ -899,7 +899,7 @@ class TestNC2MMD(unittest.TestCase):
             'tests/data/reference_nc_attrs_multiple_and_contributor.nc',
             check_only=True
         )
-        ncin = Dataset(md.netcdf_product)
+        ncin = Dataset(md.netcdf_file)
         value = md.get_personnel(mmd_yaml['personnel'], ncin)
         self.assertEqual(value[0]['name'], 'Trygve')
         self.assertEqual(value[1]['name'], 'Nina')
@@ -923,7 +923,7 @@ class TestNC2MMD(unittest.TestCase):
             'tests/data/reference_nc_attrs_multiple_and_contributor.nc',
             check_only=True
         )
-        ncin = Dataset(md.netcdf_product)
+        ncin = Dataset(md.netcdf_file)
         value = md.get_personnel(mmd_yaml['personnel'], ncin)
         self.assertEqual(value[0]['name'], 'Trygve')
         self.assertEqual(value[1]['name'], 'Nina')
@@ -940,7 +940,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
-        ncin = Dataset(md.netcdf_product)
+        ncin = Dataset(md.netcdf_file)
         value = md.get_personnel(mmd_yaml['personnel'], ncin)
         self.assertEqual(value[0]['email'], 'post@met.no')
 
@@ -950,7 +950,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
-        ncin = Dataset(md.netcdf_product)
+        ncin = Dataset(md.netcdf_file)
         value = md.get_acdd_metadata(
             mmd_yaml['iso_topic_category'], ncin, 'iso_topic_category'
         )
@@ -966,7 +966,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd('tests/data/reference_nc_missing_keywords_vocab.nc', check_only=True)
-        ncin = Dataset(md.netcdf_product, "w", diskless=True)
+        ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.platform = 'Suomi National Polar-orbiting Partnership'
         ncin.instrument = 'ASAR'
         ncin.instrument_vocabulary = 'not a valid vocab url'
@@ -982,7 +982,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.fail_nc, check_only=True)
-        ncin = Dataset(md.netcdf_product, "w", diskless=True)
+        ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.platform = 'Envisat'
         ncin.platform_vocabulary = 'invalid_url'
         value = md.get_platforms(mmd_yaml['platform'], ncin)
@@ -998,7 +998,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.fail_nc, check_only=True)
-        ncin = Dataset(md.netcdf_product, "w", diskless=True)
+        ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.platform = 'Envisat'
         value = md.get_platforms(mmd_yaml['platform'], ncin)
         self.assertEqual(value, [{'long_name': 'Envisat', 'short_name': ''}])
@@ -1011,7 +1011,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd('tests/data/reference_nc_missing_keywords_vocab.nc', check_only=True)
-        ncin = Dataset(md.netcdf_product)
+        ncin = Dataset(md.netcdf_file)
         value = md.get_platforms(mmd_yaml['platform'], ncin)
         resource_link = 'https://www.wmo-sat.info/oscar/satellites/view/snpp'
         self.assertEqual(value[0]['resource'], resource_link)
@@ -1022,7 +1022,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd('tests/data/reference_nc_fail.nc', check_only=True)
-        ncin = Dataset(md.netcdf_product)
+        ncin = Dataset(md.netcdf_file)
         md.get_keywords(mmd_yaml['keywords'], ncin)
         self.assertEqual(
             md.missing_attributes['errors'][0],
@@ -1042,7 +1042,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.fail_nc, check_only=True)
-        ncin = Dataset(md.netcdf_product, "w", diskless=True)
+        ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.keywords = "GCMDSK:Earth Science > Atmosphere > Atmospheric radiation, " \
                         "GEMET:Meteorological geographical features, " \
                         "GEMET:Atmospheric conditions, " \
@@ -1062,7 +1062,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.fail_nc, check_only=True)
-        ncin = Dataset(md.netcdf_product, "w", diskless=True)
+        ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.keywords = "GCMDSK:Earth Science > Atmosphere > Atmospheric radiation, " \
                         "GEMET:Meteorological geographical features, " \
                         "GEMET:Atmospheric conditions, " \
@@ -1086,7 +1086,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd('tests/data/reference_nc_missing_keywords_vocab.nc', check_only=True)
-        ncin = Dataset(md.netcdf_product)
+        ncin = Dataset(md.netcdf_file)
         md.get_keywords(mmd_yaml['keywords'], ncin)
         self.assertEqual(
             md.missing_attributes['errors'][0],
@@ -1099,7 +1099,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
-        ncin = Dataset(md.netcdf_product)
+        ncin = Dataset(md.netcdf_file)
         value = md.get_keywords(mmd_yaml['keywords'], ncin)
         self.assertEqual(value[0]['vocabulary'], 'GCMDSK')
         self.assertEqual(
@@ -1122,7 +1122,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd('tests/data/reference_nc_attrs_multiple.nc', check_only=True)
-        ncin = Dataset(md.netcdf_product)
+        ncin = Dataset(md.netcdf_file)
         value = md.get_keywords(mmd_yaml['keywords'], ncin)
         self.assertEqual(value[0]['vocabulary'], 'GCMDSK')
         self.assertEqual(
@@ -1140,7 +1140,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
-        ncin = Dataset(md.netcdf_product)
+        ncin = Dataset(md.netcdf_file)
         value = md.get_platforms(mmd_yaml['platform'], ncin)
         self.assertEqual(
             value[0]['long_name'],
@@ -1157,7 +1157,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd('tests/data/reference_nc_gcmd_platform.nc', check_only=True)
-        ncin = Dataset(md.netcdf_product)
+        ncin = Dataset(md.netcdf_file)
         value = md.get_platforms(mmd_yaml['platform'], ncin)
         self.assertEqual(value[0]['short_name'], 'Sentinel-1B')
         self.assertEqual(value[0]['long_name'], 'Sentinel-1B')
@@ -1169,7 +1169,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
-        ncin = Dataset(md.netcdf_product)
+        ncin = Dataset(md.netcdf_file)
         value = md.get_projects(mmd_yaml['project'], ncin)
         self.assertEqual(value[0]['long_name'], 'MET Norway core services')
 
@@ -1179,7 +1179,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd('tests/data/reference_nc_missing_keywords_vocab.nc', check_only=True)
-        ncin = Dataset(md.netcdf_product)
+        ncin = Dataset(md.netcdf_file)
         value = md.get_dataset_citations(mmd_yaml['dataset_citation'], ncin)
         self.assertEqual(value[0]['author'],
                          'DIVISION FOR OBSERVATION QUALITY AND DATA PROCESSING')
@@ -1196,7 +1196,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.fail_nc, check_only=True)
-        ncin = Dataset(md.netcdf_product, "w", diskless=True)
+        ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.creator_name = "Tester Test"
         ncin.date_created = "2022-11-04T11:06:10Z"
         ncin.title = "Test dataset"
@@ -1222,7 +1222,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
-        ncin = Dataset(md.netcdf_product)
+        ncin = Dataset(md.netcdf_file)
         value = md.get_dataset_citations(mmd_yaml['dataset_citation'], ncin)
         self.assertEqual(
             value[0]['title'],
@@ -1234,7 +1234,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
-        ncin = Dataset(md.netcdf_product, "w", diskless=True)
+        ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.time_coverage_start = "2020-11-27T13:40:02.019817Z"
         ncin.time_coverage_end = "2020-11-27T13:51:24.401505Z"
         ncin.creator_name = 'Kreator Kreatorsen'
@@ -1273,12 +1273,13 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_get_data_access_dict_with_wms(self):
         """ToDo: Add docstring"""
-        md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
-        ncin = Dataset(md.netcdf_product)
-        md.netcdf_product = (
+        netcdf_file = 'tests/data/reference_nc.nc'
+        opendap_url = (
             'https://thredds.met.no/thredds/dodsC/arcticdata/'
             'S2S_drift_TCD/SIDRIFT_S2S_SH/2019/07/31/'
-        ) + md.netcdf_product
+        ) + netcdf_file
+        md = Nc_to_mmd(netcdf_file, opendap_url, check_only=True)
+        ncin = Dataset(md.netcdf_file)
         data = md.get_data_access_dict(ncin, add_wms_data_access=True)
         self.assertEqual(data[0]['type'], 'OPeNDAP')
         self.assertEqual(data[1]['type'], 'OGC WMS')
@@ -1286,12 +1287,13 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_get_data_access_dict(self):
         """ToDo: Add docstring"""
-        md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
-        ncin = Dataset(md.netcdf_product)
-        md.netcdf_product = (
+        netcdf_file = 'tests/data/reference_nc.nc'
+        opendap_url = (
             'https://thredds.met.no/thredds/dodsC/arcticdata/'
             'S2S_drift_TCD/SIDRIFT_S2S_SH/2019/07/31/'
-        ) + md.netcdf_product
+        ) + netcdf_file
+        md = Nc_to_mmd(netcdf_file, opendap_url, check_only=True)
+        ncin = Dataset(md.netcdf_file)
         data = md.get_data_access_dict(ncin)
         self.assertEqual(data[0]['type'], 'OPeNDAP')
         self.assertEqual(data[1]['type'], 'HTTP')
@@ -1318,7 +1320,7 @@ class TestNC2MMD(unittest.TestCase):
         # Only one value in the list
         mmd_yaml['metadata_identifier']['acdd'] = {'id': {}}
         md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
-        ncin = Dataset(md.netcdf_product)
+        ncin = Dataset(md.netcdf_file)
         with self.assertRaises(AttributeError) as e:
             md.get_metadata_identifier(mmd_yaml['metadata_identifier'], ncin)
         self.assertEqual(
@@ -1385,7 +1387,7 @@ class TestNC2MMD(unittest.TestCase):
         )
         # The id attribute is not a uuid
         md = Nc_to_mmd('tests/data/reference_nc_fail.nc', check_only=True)
-        ncin = Dataset(md.netcdf_product)
+        ncin = Dataset(md.netcdf_file)
         value = md.get_metadata_identifier(mmd_yaml['metadata_identifier'], ncin)
         self.assertFalse(Nc_to_mmd.is_valid_uuid(value))
         self.assertEqual(':', value)
@@ -1408,7 +1410,7 @@ class TestNC2MMD(unittest.TestCase):
         )
         # The id attribute is a uuid
         md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
-        ncin = Dataset(md.netcdf_product)
+        ncin = Dataset(md.netcdf_file)
         value = md.get_metadata_identifier(mmd_yaml['metadata_identifier'], ncin)
         self.assertEqual(value, 'no.met:b7cb7934-77ca-4439-812e-f560df3fe7eb')
 
@@ -1416,12 +1418,11 @@ class TestNC2MMD(unittest.TestCase):
         """Test that an AttributeError is raised for missing id
         attribute.
         """
-        tested = tempfile.mkstemp()[1]
         # nc file is missing the id attribute
-        md = Nc_to_mmd('tests/data/reference_nc_id_missing.nc', output_file=tested)
+        md = Nc_to_mmd('tests/data/reference_nc_id_missing.nc', check_only=True)
         with self.assertRaises(AttributeError):
             md.to_mmd()
-        ncin = Dataset(md.netcdf_product)
+        ncin = Dataset(md.netcdf_file)
         mmd_yaml = yaml.load(
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
@@ -1439,21 +1440,19 @@ class TestNC2MMD(unittest.TestCase):
         """Test that we cannot create an MMD file if the netcdf id
         attribute is not a valid uuid.
         """
-        tested = tempfile.mkstemp()[1]
         # The id attribute is not a uuid
-        md = Nc_to_mmd('tests/data/reference_nc_id_not_uuid.nc', output_file=tested)
+        md = Nc_to_mmd('tests/data/reference_nc_id_not_uuid.nc', check_only=True)
         with self.assertRaises(AttributeError):
             md.to_mmd()
         self.assertFalse(Nc_to_mmd.is_valid_uuid(md.metadata['metadata_identifier']))
         self.assertEqual(':', md.metadata['metadata_identifier'])
 
-    def test__to_mmd__error_if_accd_id_is_invalid(self):
+    def test__to_mmd__error_if_acdd_id_is_invalid(self):
         """Test that metadata_identifier is set to an empty string, and
         that an exception is raised if the ACDD id is not a valid uuid.
         """
-        tested = tempfile.mkstemp()[1]
         # The id attribute is not a uuid
-        md = Nc_to_mmd('tests/data/reference_nc_id_not_uuid.nc', output_file=tested)
+        md = Nc_to_mmd('tests/data/reference_nc_id_not_uuid.nc', check_only=True)
         with self.assertRaises(AttributeError):
             md.to_mmd()
         self.assertEqual(
@@ -1467,7 +1466,7 @@ class TestNC2MMD(unittest.TestCase):
             )
         )
         self.assertFalse(Nc_to_mmd.is_valid_uuid(md.metadata['metadata_identifier']))
-        ncin = Dataset(md.netcdf_product)
+        ncin = Dataset(md.netcdf_file)
         id = ncin.getncattr('id')
         self.assertNotEqual(id, md.metadata['metadata_identifier'])
         self.assertEqual(':', md.metadata['metadata_identifier'])
@@ -1476,11 +1475,10 @@ class TestNC2MMD(unittest.TestCase):
         """Test that the id attribute in the netcdf file is valid, and
         used in the MMD xml file.
         """
-        tested = tempfile.mkstemp()[1]
         # The id attribute is a uuid
-        md = Nc_to_mmd('tests/data/reference_nc.nc', output_file=tested)
+        md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
         md.to_mmd()
-        ncin = Dataset(md.netcdf_product)
+        ncin = Dataset(md.netcdf_file)
         id = ncin.getncattr('id')
         self.assertEqual(md.missing_attributes['errors'], [])
         self.assertTrue(id in md.metadata['metadata_identifier'])
@@ -1491,8 +1489,10 @@ class TestNC2MMD(unittest.TestCase):
         Please add new fields to test as needed..
         """
         tested = tempfile.mkstemp()[1]
-        # md = Nc_to_mmd(self.reference_nc, output_file=tested)
-        md = Nc_to_mmd('tests/data/reference_nc_with_altID_multiple.nc', output_file=tested)
+        md = Nc_to_mmd(
+            'tests/data/reference_nc_with_altID_multiple.nc',
+            'https://thredds.met.no/thredds/dodsC/reference_nc_with_altID_multiple.nc',
+            output_file=tested)
         md.to_mmd(checksum_calculation=True)
         xsd_obj = etree.XMLSchema(etree.parse(self.reference_xsd))
         xml_doc = etree.ElementTree(file=tested)
@@ -1518,7 +1518,7 @@ class TestNC2MMD(unittest.TestCase):
         function if a default value is used for a required element.
         """
         md = Nc_to_mmd('tests/data/reference_nc_id_missing.nc', check_only=True)
-        ncin = Dataset(md.netcdf_product)
+        ncin = Dataset(md.netcdf_file)
         mmd_yaml = yaml.load(
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
@@ -1536,8 +1536,7 @@ class TestNC2MMD(unittest.TestCase):
     def test_create_mmd_2(self):
         """ToDo: Add docstring"""
         self.maxDiff = None
-        tested = tempfile.mkstemp()[1]
-        md = Nc_to_mmd(self.fail_nc, output_file=tested)
+        md = Nc_to_mmd(self.fail_nc, check_only=True)
         with self.assertRaises(AttributeError):
             md.to_mmd()
 
@@ -1552,7 +1551,10 @@ class TestNC2MMD(unittest.TestCase):
         ]
         for file in valid_files:
             tested = tempfile.mkstemp()[1]
-            md = Nc_to_mmd(file, output_file=tested)
+            md = Nc_to_mmd(
+                file,
+                os.path.join('https://thredds.met.no/thredds/dodsC/', file),
+                output_file=tested)
             md.to_mmd(checksum_calculation=True)
             xsd_obj = etree.XMLSchema(etree.parse(self.reference_xsd))
             xml_doc = etree.ElementTree(file=tested)
@@ -1565,7 +1567,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.fail_nc, check_only=True)
-        ncin = Dataset(md.netcdf_product)
+        ncin = Dataset(md.netcdf_file)
         value = md.get_data_centers(mmd_yaml['data_center'], ncin)
         self.assertEqual(value, [{
             'data_center_name': {
@@ -1583,7 +1585,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.fail_nc, check_only=True)
-        ncin = Dataset(md.netcdf_product)
+        ncin = Dataset(md.netcdf_file)
         md.get_metadata_updates(mmd_yaml['last_metadata_update'], ncin)
         self.assertEqual(
             md.missing_attributes['errors'][0],
@@ -1601,7 +1603,7 @@ class TestNC2MMD(unittest.TestCase):
         )
         md = Nc_to_mmd(self.reference_nc, check_only=True)
         # To overwrite date_created, wihtout saving it to file we use diskless
-        ncin = Dataset(md.netcdf_product)
+        ncin = Dataset(md.netcdf_file)
         data = md.get_dataset_citations(mmd_yaml['dataset_citation'], ncin)
         self.assertEqual(
             data[0]['title'],
@@ -1616,7 +1618,7 @@ class TestNC2MMD(unittest.TestCase):
         )
         md = Nc_to_mmd(self.fail_nc, check_only=True)
         # To overwrite date_created, wihtout saving it to file we use diskless
-        ncin = Dataset(md.netcdf_product, "w", diskless=True)
+        ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.date_created = '2019/01/01 00:00:00'
         ncin.date_metadata_modified = '2020/01/01 00:00:00'
         md.get_metadata_updates(mmd_yaml['last_metadata_update'], ncin)
@@ -1638,7 +1640,7 @@ class TestNC2MMD(unittest.TestCase):
         )
         md = Nc_to_mmd(self.fail_nc, check_only=True)
         # To overwrite date_created, wihtout saving it to file we use diskless
-        ncin = Dataset(md.netcdf_product, "w", diskless=True)
+        ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.date_created = '2019-01-01T00:00:00Z'
         ncin.date_metadata_modified = '2020-01-01T00:00:00Z'
         md.get_metadata_updates(mmd_yaml['last_metadata_update'], ncin)
@@ -1656,7 +1658,7 @@ class TestNC2MMD(unittest.TestCase):
         )
         md = Nc_to_mmd(self.fail_nc, check_only=True)
         # To overwrite date_created, wihtout saving it to file we use diskless
-        ncin = Dataset(md.netcdf_product, "w", diskless=True)
+        ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.date_created = '2020-01-01T00:00:00Z'
         data = md.get_metadata_updates(mmd_yaml['last_metadata_update'], ncin)
         self.assertIn(
@@ -1678,7 +1680,7 @@ class TestNC2MMD(unittest.TestCase):
             'new_name_for_date_created': {},  # this will cause an error
             'date_metadata_modified': {}}
         md = Nc_to_mmd(self.reference_nc, check_only=True)
-        ncin = Dataset(md.netcdf_product)
+        ncin = Dataset(md.netcdf_file)
         with self.assertRaises(AttributeError) as context1:
             md.get_metadata_updates(in_dict, ncin)
         self.assertTrue(
@@ -1703,7 +1705,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.fail_nc, check_only=True)
-        ncin = Dataset(md.netcdf_product)
+        ncin = Dataset(md.netcdf_file)
         md.get_abstracts(mmd_yaml['abstract'], ncin)
         self.assertEqual(
             md.missing_attributes['errors'][0],
@@ -1716,7 +1718,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
-        ncin = Dataset(md.netcdf_product)
+        ncin = Dataset(md.netcdf_file)
         value = md.get_dataset_citations(mmd_yaml['dataset_citation'], ncin)
         dt = isoparse(value[0]['publication_date'])
         self.assertEqual(dt.year, 2020)
@@ -1730,7 +1732,8 @@ class TestNC2MMD(unittest.TestCase):
         """ToDo: Add docstring"""
         tested = tempfile.mkstemp()[1]
         fn = 'tests/data/reference_nc.nc'
-        md = Nc_to_mmd(fn, check_only=True)
+        md = Nc_to_mmd(fn, os.path.join('https://thredds.met.no/thredds/dodsC/',
+                       os.path.basename(fn)), check_only=True)
         md.to_mmd(checksum_calculation=True)
         checksum = md.metadata['storage_information']['checksum']
         with open(tested, 'w') as tt:
@@ -1795,7 +1798,7 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_check_attributes_not_empty(self):
         md = Nc_to_mmd(self.fail_nc, check_only=True)
-        ncin = Dataset(md.netcdf_product, "w", diskless=True)
+        ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.geospatial_bounds = ""
         with self.assertRaises(ValueError) as e:
             md.check_attributes_not_empty(ncin)
@@ -1808,7 +1811,7 @@ class TestNC2MMD(unittest.TestCase):
         a bug. This test checks that 0 is accepted.
         """
         md = Nc_to_mmd(self.fail_nc, check_only=True)
-        ncin = Dataset(md.netcdf_product, "w", diskless=True)
+        ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.subswath = 0
         self.assertEqual(None, md.check_attributes_not_empty(ncin))
 
@@ -1817,7 +1820,7 @@ class TestNC2MMD(unittest.TestCase):
         attribute featureType is missing.
         """
         md = Nc_to_mmd(self.fail_nc, check_only=True)
-        ncin = Dataset(md.netcdf_product, "w", diskless=True)
+        ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.tull = "tull"
         md.check_feature_type(ncin)
         self.assertEqual(
@@ -1832,7 +1835,7 @@ class TestNC2MMD(unittest.TestCase):
         attribute featureType is wrong.
         """
         md = Nc_to_mmd(self.fail_nc, check_only=True)
-        ncin = Dataset(md.netcdf_product, "w", diskless=True)
+        ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.featureType = "tull"
         md.check_feature_type(ncin)
         self.assertEqual(
@@ -1844,7 +1847,7 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_check_conventions__missing(self):
         md = Nc_to_mmd(self.fail_nc, check_only=True)
-        ncin = Dataset(md.netcdf_product, "w", diskless=True)
+        ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.tull = "tull"
         md.check_conventions(ncin)
         self.assertEqual(
@@ -1855,7 +1858,7 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_check_conventions__cf_and_acdd_missing(self):
         md = Nc_to_mmd(self.fail_nc, check_only=True)
-        ncin = Dataset(md.netcdf_product, "w", diskless=True)
+        ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.Conventions = "tull"
         md.check_conventions(ncin)
         self.assertEqual(
@@ -1874,7 +1877,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.fail_nc, check_only=True)
-        ncin = Dataset(md.netcdf_product, "w", diskless=True)
+        ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.institution_short_name = "NO/MPE/NVE"
         md.get_data_centers(mmd_yaml['data_center'], ncin)
         self.assertEqual(
@@ -1886,7 +1889,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.fail_nc, check_only=True)
-        ncin = Dataset(md.netcdf_product, "w", diskless=True)
+        ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.institution = "Norwegian Meteorological Institute"
         md.get_data_centers(mmd_yaml['data_center'], ncin)
         self.assertEqual(
@@ -1899,7 +1902,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.fail_nc, check_only=True)
-        ncin = Dataset(md.netcdf_product, "w", diskless=True)
+        ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.references = (
             "https://data.met.no/dataset/3f9974bf-b073-4c16-81d8-c34fcf3b1f01"
             "(Dataset landing page),"
@@ -1919,7 +1922,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.fail_nc, check_only=True)
-        ncin = Dataset(md.netcdf_product, "w", diskless=True)
+        ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.references = (
             "https://data.met.no/dataset/3f9974bf-b073-4c16-81d8-c34fcf3b1f01"
             " (Dataset landing page),"  # added a space
@@ -1942,7 +1945,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.fail_nc, check_only=True)
-        ncin = Dataset(md.netcdf_product, "w", diskless=True)
+        ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.references = (
             "https://data.met.no/dataset/3f9974bf-b073-4c16-81d8-c34fcf3b1f01"
             "(kjhf),"
@@ -1965,7 +1968,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.fail_nc, check_only=True)
-        ncin = Dataset(md.netcdf_product, "w", diskless=True)
+        ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.references = (
             "https://data.invalid_domain.no/dataset/3f9974bf-b073-4c16-81d8-c34fcf3b1f01"
             "(Dataset landing page),"
@@ -1988,7 +1991,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.fail_nc, check_only=True)
-        ncin = Dataset(md.netcdf_product, "w", diskless=True)
+        ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.references = "landing_page, paper"
         data = md.get_related_information(mmd_yaml['related_information'], ncin)
         self.assertEqual(data, [])

--- a/tests/test_nc_to_mmd.py
+++ b/tests/test_nc_to_mmd.py
@@ -1775,19 +1775,6 @@ class TestNC2MMD(unittest.TestCase):
             'geospatial_lat_max is a required attribute'
         )
 
-    @patch('py_mmd_tools.nc_to_mmd.wget.download')
-    @patch('py_mmd_tools.nc_to_mmd.os.remove')
-    def test_file_on_thredds(self, mock_remove, mock_download):
-        """Check that file is downloaded for checksum calculation and then removed"""
-        fn = 'tests/data/dodsC/reference_nc.nc'
-        mock_download.return_value = fn
-        md = Nc_to_mmd(fn, check_only=True)
-        md.to_mmd()
-        self.assertEqual(
-            md.metadata['storage_information']['file_name'],
-            'reference_nc.nc'
-        )
-
     def test_access_constraint(self):
         """ToDo: Add docstring"""
         tempfile.mkstemp()[1]

--- a/tests/test_nc_to_mmd.py
+++ b/tests/test_nc_to_mmd.py
@@ -40,7 +40,7 @@ warnings.simplefilter("ignore", ResourceWarning)
 def test_checksum(monkeypatch):
     """Verify that the checksum created in nc_to_mmd.py is correct"""
     tested = tempfile.mkstemp()[1]
-    fn = 'tests/data/reference_nc.nc'
+    fn = os.path.abspath('tests/data/reference_nc.nc')
     url = os.path.join('https://thredds.met.no/thredds/dodsC/', os.path.basename(fn))
     with monkeypatch.context() as mp:
         mp.setattr("py_mmd_tools.nc_to_mmd.Dataset",
@@ -61,7 +61,7 @@ def test_create_mmd_1(monkeypatch):
     Please add new fields to test as needed..
     """
     tested = tempfile.mkstemp()[1]
-    fn = 'tests/data/reference_nc_with_altID_multiple.nc'
+    fn = os.path.abspath('tests/data/reference_nc_with_altID_multiple.nc')
     url = 'https://thredds.met.no/thredds/dodsC/reference_nc_with_altID_multiple.nc'
     with monkeypatch.context() as mp:
         mp.setattr("py_mmd_tools.nc_to_mmd.Dataset",
@@ -86,7 +86,7 @@ def test_create_mmd_1(monkeypatch):
 @pytest.mark.py_mmd_tools
 def test_get_data_access_dict_with_wms(monkeypatch):
     """ToDo: Add docstring"""
-    netcdf_file = 'tests/data/reference_nc.nc'
+    netcdf_file = os.path.abspath('tests/data/reference_nc.nc')
     opendap_url = (
         'https://thredds.met.no/thredds/dodsC/arcticdata/'
         'S2S_drift_TCD/SIDRIFT_S2S_SH/2019/07/31/'
@@ -105,7 +105,7 @@ def test_get_data_access_dict_with_wms(monkeypatch):
 @pytest.mark.py_mmd_tools
 def test_get_data_access_dict(monkeypatch):
     """ToDo: Add docstring"""
-    netcdf_file = 'tests/data/reference_nc.nc'
+    netcdf_file = os.path.abspath('tests/data/reference_nc.nc')
     opendap_url = (
         'https://thredds.met.no/thredds/dodsC/arcticdata/'
         'S2S_drift_TCD/SIDRIFT_S2S_SH/2019/07/31/'
@@ -118,6 +118,14 @@ def test_get_data_access_dict(monkeypatch):
         data = md.get_data_access_dict(ncin)
     assert data[0]['type'] == 'OPeNDAP'
     assert data[1]['type'] == 'HTTP'
+
+
+@pytest.mark.py_mmd_tools
+def test_not_absolute_path():
+    fn = 'tests/data/reference_nc.nc'
+    with pytest.raises(ValueError) as ve:
+        md = Nc_to_mmd(fn, check_only=True)
+    assert str(ve.value) == "The path to the NetCDF-CF file must be absolute."
 
 
 class TestNCAttrsFromYaml(unittest.TestCase):
@@ -471,7 +479,8 @@ class TestNC2MMD(unittest.TestCase):
         but output_file is None. Test that this is the case.
         """
         with self.assertRaises(ValueError):
-            Nc_to_mmd('tests/data/reference_nc.nc', output_file=None, check_only=False)
+            Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), output_file=None,
+                check_only=False)
 
     @patch('metvocab.mmdgroup.MMDGroup.init_vocab')
     def test_init_raises_error_on_mmd_group(self, mock_init_vocab):
@@ -479,7 +488,8 @@ class TestNC2MMD(unittest.TestCase):
         initialised.
         """
         with self.assertRaises(ValueError):
-            Nc_to_mmd('tests/data/reference_nc.nc', output_file=None, check_only=True)
+            Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), output_file=None,
+                check_only=True)
 
     def test_default_when_no_acdd_or_acdd_ext(self):
         """ Test that a default value can be used even if no acdd
@@ -488,7 +498,7 @@ class TestNC2MMD(unittest.TestCase):
         mmd_yaml = yaml.load(
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
-        md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_acdd_metadata(
             mmd_yaml['metadata_status'],
@@ -504,7 +514,7 @@ class TestNC2MMD(unittest.TestCase):
         mmd_yaml = yaml.load(
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
-        md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
         with self.assertRaises(ValueError) as e:
             md.get_acdd_metadata(
@@ -521,7 +531,7 @@ class TestNC2MMD(unittest.TestCase):
         mmd_yaml = yaml.load(
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
-        md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_metadata_updates(mmd_yaml['last_metadata_update'], ncin)
         self.assertEqual(value['update'][0]['type'], 'Created')
@@ -549,7 +559,7 @@ class TestNC2MMD(unittest.TestCase):
         mmd_yaml = yaml.load(
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
-        md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_geographic_extent_polygon(
             mmd_yaml['geographic_extent']['polygon'], ncin
@@ -562,7 +572,8 @@ class TestNC2MMD(unittest.TestCase):
         mmd_yaml = yaml.load(
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
-        md = Nc_to_mmd('tests/data/reference_nc_missing_attrs.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_missing_attrs.nc'),
+            check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_acdd_metadata(mmd_yaml['geographic_extent'], ncin, 'geographic_extent')
         self.assertEqual(value['rectangle']['north'], None)
@@ -583,7 +594,7 @@ class TestNC2MMD(unittest.TestCase):
         mmd_yaml = yaml.load(
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
-        md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.geospatial_lat_max = "60.158733f; // float"
         ncin.geospatial_lat_min = "59.78492f; // float"
@@ -602,7 +613,8 @@ class TestNC2MMD(unittest.TestCase):
         yaml.load(
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
-        md = Nc_to_mmd('tests/data/reference_nc_missing_rectangle.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_missing_rectangle.nc'),
+            check_only=True)
         md.to_mmd(geographic_extent_rectangle={
             'geospatial_lat_max': 90,
             'geospatial_lat_min': -90,
@@ -615,21 +627,23 @@ class TestNC2MMD(unittest.TestCase):
         """Test that an error is raised if the collection input
         parameter is wrong type.
         """
-        md = Nc_to_mmd('tests/data/reference_nc_missing_attrs.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_missing_attrs.nc'),
+            check_only=True)
         with self.assertRaises(ValueError) as e:
             md.to_mmd(collection=2)
         self.assertEqual(str(e.exception), 'collection must be of type str')
 
     def test_collection_not_set(self):
         """ToDo: Add docstring"""
-        md = Nc_to_mmd('tests/data/reference_nc_missing_collection.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_missing_collection.nc'),
+            check_only=True)
         req_ok, msg = md.to_mmd()
         self.assertTrue(req_ok)
         self.assertEqual(md.metadata['collection'], ['METNCS'])
 
     def test_collection_set(self):
         """ToDo: Add docstring"""
-        md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         status, msg = md.to_mmd(collection='ADC')
         # nc files should normally not have a collection element, as this is
         # set during harvesting
@@ -641,7 +655,7 @@ class TestNC2MMD(unittest.TestCase):
         mmd_yaml = yaml.load(
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
-        md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_abstracts(mmd_yaml['abstract'], ncin)
         self.assertEqual(type(value), list)
@@ -653,7 +667,7 @@ class TestNC2MMD(unittest.TestCase):
         mmd_yaml = yaml.load(
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
-        md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_titles(mmd_yaml['title'], ncin)
         self.assertEqual(type(value), list)
@@ -670,7 +684,7 @@ class TestNC2MMD(unittest.TestCase):
         mmd_yaml = yaml.load(
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
-        md = Nc_to_mmd('tests/data/reference_nc_id_missing.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_id_missing.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_titles(mmd_yaml['title'], ncin)
         self.assertEqual(type(value), list)
@@ -682,7 +696,7 @@ class TestNC2MMD(unittest.TestCase):
         mmd_yaml = yaml.load(
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
-        md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_data_centers(mmd_yaml['data_center'], ncin)
         self.assertEqual(type(value), list)
@@ -697,7 +711,7 @@ class TestNC2MMD(unittest.TestCase):
     def test_data_access(self):
         """ToDo: Add docstring"""
         yaml.load(resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader)
-        md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         Dataset(md.netcdf_file)
         value = None
         self.assertEqual(value, None)
@@ -707,7 +721,7 @@ class TestNC2MMD(unittest.TestCase):
         mmd_yaml = yaml.load(
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
-        md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_acdd_metadata(
             mmd_yaml['dataset_production_status'], ncin, 'dataset_production_status'
@@ -721,7 +735,7 @@ class TestNC2MMD(unittest.TestCase):
         mmd_yaml = yaml.load(
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
-        md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_acdd_metadata(
             mmd_yaml['alternate_identifier'], ncin, 'alternate_identifier'
@@ -736,7 +750,7 @@ class TestNC2MMD(unittest.TestCase):
         mmd_yaml = yaml.load(
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
-        md = Nc_to_mmd('tests/data/reference_nc_with_altID.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_with_altID.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_acdd_metadata(
             mmd_yaml['alternate_identifier'], ncin, 'alternate_identifier'
@@ -751,7 +765,8 @@ class TestNC2MMD(unittest.TestCase):
         mmd_yaml = yaml.load(
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
-        md = Nc_to_mmd('tests/data/reference_nc_with_altID_multiple.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_with_altID_multiple.nc'),
+            check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_acdd_metadata(
             mmd_yaml['alternate_identifier'], ncin, 'alternate_identifier'
@@ -765,7 +780,7 @@ class TestNC2MMD(unittest.TestCase):
         mmd_yaml = yaml.load(
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
-        md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_acdd_metadata(mmd_yaml['metadata_status'], ncin, 'metadata_status')
         self.assertEqual(value, 'Active')
@@ -775,7 +790,7 @@ class TestNC2MMD(unittest.TestCase):
         mmd_yaml = yaml.load(
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
-        md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_metadata_updates(mmd_yaml['last_metadata_update'], ncin)
         self.assertEqual(value['update'][0]['datetime'], '2020-11-27T14:05:56Z')
@@ -785,7 +800,9 @@ class TestNC2MMD(unittest.TestCase):
         mmd_yaml = yaml.load(
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
-        md = Nc_to_mmd('tests/data/reference_nc_missing_attrs.nc', check_only=True)
+        md = Nc_to_mmd(
+            os.path.abspath(os.path.abspath('tests/data/reference_nc_missing_attrs.nc')),
+            check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_personnel(mmd_yaml['personnel'], ncin)
         self.assertEqual(value[0]['role'], 'Investigator')
@@ -798,7 +815,8 @@ class TestNC2MMD(unittest.TestCase):
         mmd_yaml = yaml.load(
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
-        md = Nc_to_mmd('tests/data/reference_nc_missing_attrs.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_missing_attrs.nc'),
+            check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_temporal_extents(mmd_yaml['temporal_extent'], ncin)
         self.assertEqual(value, [])
@@ -812,7 +830,8 @@ class TestNC2MMD(unittest.TestCase):
         yaml.load(
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
-        md = Nc_to_mmd('tests/data/reference_nc_missing_attrs.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_missing_attrs.nc'),
+            check_only=True)
         with self.assertRaises(AttributeError):
             md.to_mmd(time_coverage_start='1850-01-01T00:00:00Z')
         self.assertEqual(md.metadata['temporal_extent']['start_date'],
@@ -821,7 +840,8 @@ class TestNC2MMD(unittest.TestCase):
     def test_missing_temporal_extent_but_start_and_end_provided_as_kwargs(self):
         """ToDo: Add docstring"""
         yaml.load(resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader)
-        md = Nc_to_mmd('tests/data/reference_nc_missing_attrs.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_missing_attrs.nc'),
+            check_only=True)
         with self.assertRaises(AttributeError):
             md.to_mmd(
                 time_coverage_start='1850-01-01T00:00:00Z',
@@ -834,7 +854,8 @@ class TestNC2MMD(unittest.TestCase):
     def test_missing_temporal_extent_but_start_and_end_provided_as_kwargs_and_wrong(self):
         """Test that errors are raised when input times are not iso"""
         yaml.load(resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader)
-        md = Nc_to_mmd('tests/data/reference_nc_missing_attrs.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_missing_attrs.nc'),
+            check_only=True)
         with self.assertRaises(AttributeError):
             md.to_mmd(
                 time_coverage_start='1850/01/01 00:00:00',
@@ -856,7 +877,8 @@ class TestNC2MMD(unittest.TestCase):
         mmd_yaml = yaml.load(
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
-        md = Nc_to_mmd('tests/data/reference_nc_attrs_multiple.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_attrs_multiple.nc'),
+            check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_temporal_extents(mmd_yaml['temporal_extent'], ncin)
         self.assertEqual(value[0]['start_date'], '2020-11-27T13:40:02.019817Z')
@@ -872,7 +894,8 @@ class TestNC2MMD(unittest.TestCase):
         mmd_yaml = yaml.load(
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
-        md = Nc_to_mmd('tests/data/reference_nc_attrs_multiple.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_attrs_multiple.nc'),
+            check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
 
         valid_start = '2020-11-27T13:40:02.019817Z'
@@ -936,7 +959,7 @@ class TestNC2MMD(unittest.TestCase):
         mmd_yaml = yaml.load(
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
-        md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_temporal_extents(mmd_yaml['temporal_extent'], ncin)
         self.assertEqual(value[0]['start_date'], '2020-11-27T13:40:02.019817Z')
@@ -950,7 +973,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(
-            'tests/data/reference_nc_attrs_multiple_mixed_creator.nc',
+            os.path.abspath('tests/data/reference_nc_attrs_multiple_mixed_creator.nc'),
             check_only=True
         )
         ncin = Dataset(md.netcdf_file)
@@ -967,7 +990,8 @@ class TestNC2MMD(unittest.TestCase):
         mmd_yaml = yaml.load(
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
-        md = Nc_to_mmd('tests/data/reference_nc_attrs_multiple.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_attrs_multiple.nc'),
+            check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_personnel(mmd_yaml['personnel'], ncin)
         self.assertEqual(value[0]['name'], 'Trygve')
@@ -983,7 +1007,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(
-            'tests/data/reference_nc_attrs_multiple_and_contributor.nc',
+            os.path.abspath('tests/data/reference_nc_attrs_multiple_and_contributor.nc'),
             check_only=True
         )
         ncin = Dataset(md.netcdf_file)
@@ -1007,7 +1031,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(
-            'tests/data/reference_nc_attrs_multiple_and_contributor.nc',
+            os.path.abspath('tests/data/reference_nc_attrs_multiple_and_contributor.nc'),
             check_only=True
         )
         ncin = Dataset(md.netcdf_file)
@@ -1026,7 +1050,7 @@ class TestNC2MMD(unittest.TestCase):
         mmd_yaml = yaml.load(
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
-        md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_personnel(mmd_yaml['personnel'], ncin)
         self.assertEqual(value[0]['email'], 'post@met.no')
@@ -1036,7 +1060,7 @@ class TestNC2MMD(unittest.TestCase):
         mmd_yaml = yaml.load(
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
-        md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_acdd_metadata(
             mmd_yaml['iso_topic_category'], ncin, 'iso_topic_category'
@@ -1052,7 +1076,8 @@ class TestNC2MMD(unittest.TestCase):
         mmd_yaml = yaml.load(
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
-        md = Nc_to_mmd('tests/data/reference_nc_missing_keywords_vocab.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_missing_keywords_vocab.nc'),
+            check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.platform = 'Suomi National Polar-orbiting Partnership'
         ncin.instrument = 'ASAR'
@@ -1097,7 +1122,8 @@ class TestNC2MMD(unittest.TestCase):
         mmd_yaml = yaml.load(
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
-        md = Nc_to_mmd('tests/data/reference_nc_missing_keywords_vocab.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_missing_keywords_vocab.nc'),
+            check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_platforms(mmd_yaml['platform'], ncin)
         resource_link = 'https://www.wmo-sat.info/oscar/satellites/view/snpp'
@@ -1108,7 +1134,7 @@ class TestNC2MMD(unittest.TestCase):
         mmd_yaml = yaml.load(
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
-        md = Nc_to_mmd('tests/data/reference_nc_fail.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_fail.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
         md.get_keywords(mmd_yaml['keywords'], ncin)
         self.assertEqual(
@@ -1172,7 +1198,8 @@ class TestNC2MMD(unittest.TestCase):
         mmd_yaml = yaml.load(
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
-        md = Nc_to_mmd('tests/data/reference_nc_missing_keywords_vocab.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_missing_keywords_vocab.nc'),
+            check_only=True)
         ncin = Dataset(md.netcdf_file)
         md.get_keywords(mmd_yaml['keywords'], ncin)
         self.assertEqual(
@@ -1185,7 +1212,7 @@ class TestNC2MMD(unittest.TestCase):
         mmd_yaml = yaml.load(
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
-        md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_keywords(mmd_yaml['keywords'], ncin)
         self.assertEqual(value[0]['vocabulary'], 'GCMDSK')
@@ -1208,7 +1235,8 @@ class TestNC2MMD(unittest.TestCase):
         mmd_yaml = yaml.load(
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
-        md = Nc_to_mmd('tests/data/reference_nc_attrs_multiple.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_attrs_multiple.nc'),
+            check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_keywords(mmd_yaml['keywords'], ncin)
         self.assertEqual(value[0]['vocabulary'], 'GCMDSK')
@@ -1226,7 +1254,7 @@ class TestNC2MMD(unittest.TestCase):
         mmd_yaml = yaml.load(
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
-        md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_platforms(mmd_yaml['platform'], ncin)
         self.assertEqual(
@@ -1243,7 +1271,8 @@ class TestNC2MMD(unittest.TestCase):
         mmd_yaml = yaml.load(
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
-        md = Nc_to_mmd('tests/data/reference_nc_gcmd_platform.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_gcmd_platform.nc'),
+            check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_platforms(mmd_yaml['platform'], ncin)
         self.assertEqual(value[0]['short_name'], 'Sentinel-1B')
@@ -1255,7 +1284,7 @@ class TestNC2MMD(unittest.TestCase):
         mmd_yaml = yaml.load(
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
-        md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_projects(mmd_yaml['project'], ncin)
         self.assertEqual(value[0]['long_name'], 'MET Norway core services')
@@ -1265,7 +1294,8 @@ class TestNC2MMD(unittest.TestCase):
         mmd_yaml = yaml.load(
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
-        md = Nc_to_mmd('tests/data/reference_nc_missing_keywords_vocab.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_missing_keywords_vocab.nc'),
+            check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_dataset_citations(mmd_yaml['dataset_citation'], ncin)
         self.assertEqual(value[0]['author'],
@@ -1298,7 +1328,7 @@ class TestNC2MMD(unittest.TestCase):
         """Run netCDF attributes to MMD translation with check_only
         flag.
         """
-        md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         req_ok, msg = md.to_mmd()
         self.assertTrue(req_ok)
         self.assertEqual(msg, '')
@@ -1308,7 +1338,7 @@ class TestNC2MMD(unittest.TestCase):
         mmd_yaml = yaml.load(
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
-        md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_dataset_citations(mmd_yaml['dataset_citation'], ncin)
         self.assertEqual(
@@ -1320,7 +1350,7 @@ class TestNC2MMD(unittest.TestCase):
         mmd_yaml = yaml.load(
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
-        md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.time_coverage_start = "2020-11-27T13:40:02.019817Z"
         ncin.time_coverage_end = "2020-11-27T13:51:24.401505Z"
@@ -1348,20 +1378,22 @@ class TestNC2MMD(unittest.TestCase):
     def test_oserror_opendap(self, mock_nc_dataset):
         """ToDo: Add docstring"""
         mock_nc_dataset.side_effect = OSError
-        fn = (
+        fn = os.path.abspath(
+            'S1A_IW_GRDH_1SDV_20210131T172816_20210131T172841_036385_04452D_505F.nc')
+        url = (
             'http://nbstds.met.no/thredds/dodsC/NBS/S1A/2021/01/31/IW/'
             'S1A_IW_GRDH_1SDV_20210131T172816_20210131T172841_036385_04452D_505F.nc'
         )
         try:
-            Nc_to_mmd(fn, check_only=True)
+            Nc_to_mmd(fn, url, check_only=True)
         except OSError:
             pass
         mock_nc_dataset.assert_called_with(fn+'#fillmismatch')
 
     def test_related_dataset(self):
         """ToDo: Add docstring"""
-        md = Nc_to_mmd('tests/data/reference_nc_id_missing.nc', check_only=True)
-        ncin = Dataset('tests/data/reference_nc_id_missing.nc')
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_id_missing.nc'), check_only=True)
+        ncin = Dataset(os.path.abspath('tests/data/reference_nc_id_missing.nc'))
         mmd_yaml = yaml.load(
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
@@ -1379,7 +1411,7 @@ class TestNC2MMD(unittest.TestCase):
         )
         # Only one value in the list
         mmd_yaml['metadata_identifier']['acdd'] = {'id': {}}
-        md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
         with self.assertRaises(AttributeError) as e:
             md.get_metadata_identifier(mmd_yaml['metadata_identifier'], ncin)
@@ -1430,7 +1462,7 @@ class TestNC2MMD(unittest.TestCase):
             'dummy_field': {
                 'comment': 'no comment',
                 'default': 'hei'}}
-        md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         md.to_mmd(mmd_yaml=mmd_yaml)
         self.assertEqual(
             md.missing_attributes['warnings'][2],
@@ -1446,7 +1478,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         # The id attribute is not a uuid
-        md = Nc_to_mmd('tests/data/reference_nc_fail.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_fail.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_metadata_identifier(mmd_yaml['metadata_identifier'], ncin)
         self.assertFalse(Nc_to_mmd.is_valid_uuid(value))
@@ -1469,7 +1501,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         # The id attribute is a uuid
-        md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_metadata_identifier(mmd_yaml['metadata_identifier'], ncin)
         self.assertEqual(value, 'no.met:b7cb7934-77ca-4439-812e-f560df3fe7eb')
@@ -1479,7 +1511,7 @@ class TestNC2MMD(unittest.TestCase):
         attribute.
         """
         # nc file is missing the id attribute
-        md = Nc_to_mmd('tests/data/reference_nc_id_missing.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_id_missing.nc'), check_only=True)
         with self.assertRaises(AttributeError):
             md.to_mmd()
         ncin = Dataset(md.netcdf_file)
@@ -1501,7 +1533,7 @@ class TestNC2MMD(unittest.TestCase):
         attribute is not a valid uuid.
         """
         # The id attribute is not a uuid
-        md = Nc_to_mmd('tests/data/reference_nc_id_not_uuid.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_id_not_uuid.nc'), check_only=True)
         with self.assertRaises(AttributeError):
             md.to_mmd()
         self.assertFalse(Nc_to_mmd.is_valid_uuid(md.metadata['metadata_identifier']))
@@ -1512,7 +1544,7 @@ class TestNC2MMD(unittest.TestCase):
         that an exception is raised if the ACDD id is not a valid uuid.
         """
         # The id attribute is not a uuid
-        md = Nc_to_mmd('tests/data/reference_nc_id_not_uuid.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_id_not_uuid.nc'), check_only=True)
         with self.assertRaises(AttributeError):
             md.to_mmd()
         self.assertEqual(
@@ -1536,7 +1568,7 @@ class TestNC2MMD(unittest.TestCase):
         used in the MMD xml file.
         """
         # The id attribute is a uuid
-        md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         md.to_mmd()
         ncin = Dataset(md.netcdf_file)
         id = ncin.getncattr('id')
@@ -1547,7 +1579,7 @@ class TestNC2MMD(unittest.TestCase):
         """Check that a warning is issued by the get_acdd_metadata
         function if a default value is used for a required element.
         """
-        md = Nc_to_mmd('tests/data/reference_nc_id_missing.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_id_missing.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
         mmd_yaml = yaml.load(
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
@@ -1747,7 +1779,7 @@ class TestNC2MMD(unittest.TestCase):
         mmd_yaml = yaml.load(
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
-        md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_dataset_citations(mmd_yaml['dataset_citation'], ncin)
         dt = isoparse(value[0]['publication_date'])
@@ -1760,7 +1792,7 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_checksum_off(self):
         """ToDo: Add docstring"""
-        fn = 'tests/data/reference_nc.nc'
+        fn = os.path.abspath('tests/data/reference_nc.nc')
         md = Nc_to_mmd(fn, check_only=True)
         md.to_mmd(checksum_calculation=False)
         with self.assertRaises(KeyError):
@@ -1776,7 +1808,7 @@ class TestNC2MMD(unittest.TestCase):
     def test_spatial_repr(self):
         """ToDo: Add docstring"""
         tempfile.mkstemp()[1]
-        md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         md.to_mmd()
         spatial_repr = md.metadata['spatial_representation']
         self.assertEqual(spatial_repr, 'grid')
@@ -1784,7 +1816,8 @@ class TestNC2MMD(unittest.TestCase):
     def test_spatial_repr_fail(self):
         """ToDo: Add docstring"""
         tempfile.mkstemp()[1]
-        md = Nc_to_mmd('tests/data/reference_nc_missing_spatial_repr.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_missing_spatial_repr.nc'),
+            check_only=True)
         with self.assertRaises(AttributeError):
             md.to_mmd()
         self.assertEqual(
@@ -1795,7 +1828,7 @@ class TestNC2MMD(unittest.TestCase):
     def test_access_constraint(self):
         """ToDo: Add docstring"""
         tempfile.mkstemp()[1]
-        md = Nc_to_mmd('tests/data/reference_nc.nc', check_only=True)
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         md.to_mmd()
         spatial_repr = md.metadata['access_constraint']
         self.assertEqual(spatial_repr, 'Open')

--- a/tests/test_nc_to_mmd.py
+++ b/tests/test_nc_to_mmd.py
@@ -124,7 +124,7 @@ def test_get_data_access_dict(monkeypatch):
 def test_not_absolute_path():
     fn = 'tests/data/reference_nc.nc'
     with pytest.raises(ValueError) as ve:
-        md = Nc_to_mmd(fn, check_only=True)
+        Nc_to_mmd(fn, check_only=True)
     assert str(ve.value) == "The path to the NetCDF-CF file must be absolute."
 
 
@@ -480,7 +480,7 @@ class TestNC2MMD(unittest.TestCase):
         """
         with self.assertRaises(ValueError):
             Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), output_file=None,
-                check_only=False)
+                      check_only=False)
 
     @patch('metvocab.mmdgroup.MMDGroup.init_vocab')
     def test_init_raises_error_on_mmd_group(self, mock_init_vocab):
@@ -489,7 +489,7 @@ class TestNC2MMD(unittest.TestCase):
         """
         with self.assertRaises(ValueError):
             Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), output_file=None,
-                check_only=True)
+                      check_only=True)
 
     def test_default_when_no_acdd_or_acdd_ext(self):
         """ Test that a default value can be used even if no acdd
@@ -573,7 +573,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_missing_attrs.nc'),
-            check_only=True)
+                       check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_acdd_metadata(mmd_yaml['geographic_extent'], ncin, 'geographic_extent')
         self.assertEqual(value['rectangle']['north'], None)
@@ -614,7 +614,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_missing_rectangle.nc'),
-            check_only=True)
+                       check_only=True)
         md.to_mmd(geographic_extent_rectangle={
             'geospatial_lat_max': 90,
             'geospatial_lat_min': -90,
@@ -628,7 +628,7 @@ class TestNC2MMD(unittest.TestCase):
         parameter is wrong type.
         """
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_missing_attrs.nc'),
-            check_only=True)
+                       check_only=True)
         with self.assertRaises(ValueError) as e:
             md.to_mmd(collection=2)
         self.assertEqual(str(e.exception), 'collection must be of type str')
@@ -636,7 +636,7 @@ class TestNC2MMD(unittest.TestCase):
     def test_collection_not_set(self):
         """ToDo: Add docstring"""
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_missing_collection.nc'),
-            check_only=True)
+                       check_only=True)
         req_ok, msg = md.to_mmd()
         self.assertTrue(req_ok)
         self.assertEqual(md.metadata['collection'], ['METNCS'])
@@ -766,7 +766,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_with_altID_multiple.nc'),
-            check_only=True)
+                       check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_acdd_metadata(
             mmd_yaml['alternate_identifier'], ncin, 'alternate_identifier'
@@ -816,7 +816,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_missing_attrs.nc'),
-            check_only=True)
+                       check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_temporal_extents(mmd_yaml['temporal_extent'], ncin)
         self.assertEqual(value, [])
@@ -831,7 +831,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_missing_attrs.nc'),
-            check_only=True)
+                       check_only=True)
         with self.assertRaises(AttributeError):
             md.to_mmd(time_coverage_start='1850-01-01T00:00:00Z')
         self.assertEqual(md.metadata['temporal_extent']['start_date'],
@@ -841,7 +841,7 @@ class TestNC2MMD(unittest.TestCase):
         """ToDo: Add docstring"""
         yaml.load(resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader)
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_missing_attrs.nc'),
-            check_only=True)
+                       check_only=True)
         with self.assertRaises(AttributeError):
             md.to_mmd(
                 time_coverage_start='1850-01-01T00:00:00Z',
@@ -855,7 +855,7 @@ class TestNC2MMD(unittest.TestCase):
         """Test that errors are raised when input times are not iso"""
         yaml.load(resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader)
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_missing_attrs.nc'),
-            check_only=True)
+                       check_only=True)
         with self.assertRaises(AttributeError):
             md.to_mmd(
                 time_coverage_start='1850/01/01 00:00:00',
@@ -878,7 +878,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_attrs_multiple.nc'),
-            check_only=True)
+                       check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_temporal_extents(mmd_yaml['temporal_extent'], ncin)
         self.assertEqual(value[0]['start_date'], '2020-11-27T13:40:02.019817Z')
@@ -895,7 +895,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_attrs_multiple.nc'),
-            check_only=True)
+                       check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
 
         valid_start = '2020-11-27T13:40:02.019817Z'
@@ -991,7 +991,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_attrs_multiple.nc'),
-            check_only=True)
+                       check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_personnel(mmd_yaml['personnel'], ncin)
         self.assertEqual(value[0]['name'], 'Trygve')
@@ -1077,7 +1077,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_missing_keywords_vocab.nc'),
-            check_only=True)
+                       check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.platform = 'Suomi National Polar-orbiting Partnership'
         ncin.instrument = 'ASAR'
@@ -1123,7 +1123,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_missing_keywords_vocab.nc'),
-            check_only=True)
+                       check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_platforms(mmd_yaml['platform'], ncin)
         resource_link = 'https://www.wmo-sat.info/oscar/satellites/view/snpp'
@@ -1199,7 +1199,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_missing_keywords_vocab.nc'),
-            check_only=True)
+                       check_only=True)
         ncin = Dataset(md.netcdf_file)
         md.get_keywords(mmd_yaml['keywords'], ncin)
         self.assertEqual(
@@ -1236,7 +1236,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_attrs_multiple.nc'),
-            check_only=True)
+                       check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_keywords(mmd_yaml['keywords'], ncin)
         self.assertEqual(value[0]['vocabulary'], 'GCMDSK')
@@ -1272,7 +1272,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_gcmd_platform.nc'),
-            check_only=True)
+                       check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_platforms(mmd_yaml['platform'], ncin)
         self.assertEqual(value[0]['short_name'], 'Sentinel-1B')
@@ -1295,7 +1295,7 @@ class TestNC2MMD(unittest.TestCase):
             resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_missing_keywords_vocab.nc'),
-            check_only=True)
+                       check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_dataset_citations(mmd_yaml['dataset_citation'], ncin)
         self.assertEqual(value[0]['author'],
@@ -1817,7 +1817,7 @@ class TestNC2MMD(unittest.TestCase):
         """ToDo: Add docstring"""
         tempfile.mkstemp()[1]
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_missing_spatial_repr.nc'),
-            check_only=True)
+                       check_only=True)
         with self.assertRaises(AttributeError):
             md.to_mmd()
         self.assertEqual(

--- a/tests/test_nc_to_mmd.py
+++ b/tests/test_nc_to_mmd.py
@@ -31,7 +31,6 @@ from py_mmd_tools.yaml_to_adoc import repetition_allowed
 from py_mmd_tools.yaml_to_adoc import set_attribute
 from py_mmd_tools.yaml_to_adoc import set_attributes
 
-from tests.test_nc2mmd_script import MockDataset
 from tests.test_nc2mmd_script import patchedDataset
 
 warnings.simplefilter("ignore", ResourceWarning)
@@ -77,11 +76,11 @@ def test_create_mmd_1(monkeypatch):
     """ Check content of the xml_doc """
     # alternate_identifier
     assert xml_doc.getroot().find(
-            "{http://www.met.no/schema/mmd}alternate_identifier[@type='dummy_type']"
-        ).text == "dummy_id_no1"
+        "{http://www.met.no/schema/mmd}alternate_identifier[@type='dummy_type']"
+    ).text == "dummy_id_no1"
     assert xml_doc.getroot().find(
-            "{http://www.met.no/schema/mmd}alternate_identifier[@type='other_type']"
-        ).text == "dummy_id_no2"
+        "{http://www.met.no/schema/mmd}alternate_identifier[@type='other_type']"
+    ).text == "dummy_id_no2"
 
 
 @pytest.mark.py_mmd_tools


### PR DESCRIPTION
…nt to check the nc file with check_only=True

**Summary**: see #232 

**Related issue**: closes #232 

**Suggested reviewer(s)**:

**Reviewer checklist**:

- [ ] The headers of all files contain a reference to the repository license (i.e., "License: This file is part of py-mmd-tools, licensed under the Apache License 2.0 (https://www.apache.org/licenses/LICENSE-2.0)")
- [ ] 100% test coverage of new code - meaning:
    - [ ] The overall test coverage increased or remained the same as before
    - [ ] Every function is accompanied with a test suite
    - [ ] Tests are both positive (testing that the function work as intended with valid data) and negative (testing that the function behaves as expected with invalid data, e.g., that correct exceptions are thrown)
    - [ ] Functions with optional arguments have separate tests for all options
- [ ] Examples are supported by doctests
- [ ] All tests are passing
- [ ] All names (e.g., files, classes, functions, variables) are explicit
- [ ] Documentation (as docstrings) is complete and understandable

The checklist is based on the S-ENDA conventions and definition of done (see https://s-enda-documentation.readthedocs.io/en/latest/general_conventions.html). The above points are not necessarily relevant to all contributions. In that case, please add a short explanation to help the reviewer.
