### PR TITLE
#245: added a custom function for operational_status

### DIFF
--- a/py_mmd_tools/mmd_elements.yaml
+++ b/py_mmd_tools/mmd_elements.yaml
@@ -240,7 +240,7 @@ operational_status:
     processing_level:
       maxOccurs: '1'
       comment: Optional
-      description: A textual description of the processing (or quality control) level of the data. Valid keywords are listed in https://htmlpreview.github.io/?https://github.com/metno/mmd/blob/master/doc/mmd-specification.html#operational-status[Section 4.5 of the MMD specification].
+      description: A textual description of the processing level of the data. Valid keywords are listed in https://htmlpreview.github.io/?https://github.com/metno/mmd/blob/master/doc/mmd-specification.html#operational-status[Section 4.5 of the MMD specification].
 
 access_constraint:
   maxOccurs: '1'

--- a/py_mmd_tools/nc_to_mmd.py
+++ b/py_mmd_tools/nc_to_mmd.py
@@ -34,7 +34,7 @@ from metvocab.mmdgroup import MMDGroup
 import pathlib
 from netCDF4 import Dataset
 
-from shapely.errors import WKTReadingError
+from shapely.errors import ShapelyError
 
 
 def valid_url(url):
@@ -917,7 +917,7 @@ class Nc_to_mmd(object):
         wkt = eval('ncin.%s'%acdd_key)
         try:
             pp = shapely.wkt.loads(wkt)
-        except WKTReadingError:
+        except ShapelyError:
             self.missing_attributes['errors'].append(
                 '%s must be formatted as a WKT string' % acdd_key
             )

--- a/py_mmd_tools/nc_to_mmd.py
+++ b/py_mmd_tools/nc_to_mmd.py
@@ -980,11 +980,11 @@ class Nc_to_mmd(object):
         valid_statuses = [v.lower() for v in VALID]
         if ostatus.lower() not in valid_statuses:
             self.missing_attributes['errors'].append(
-                    "The ACDD attribute 'operational_status' must "
-                    "follow a controlled vocabulary from MMD (see "
-                    "https://htmlpreview.github.io/?https://github."
-                    "com/metno/mmd/blob/master/doc/mmd-specification."
-                    "html#operational-status).")
+                "The ACDD attribute 'operational_status' must "
+                "follow a controlled vocabulary from MMD (see "
+                "https://htmlpreview.github.io/?https://github."
+                "com/metno/mmd/blob/master/doc/mmd-specification."
+                "html#operational-status).")
         else:
             # Need to make a new list of lists to use the filter
             # function for comparison between ostatus and valid

--- a/py_mmd_tools/nc_to_mmd.py
+++ b/py_mmd_tools/nc_to_mmd.py
@@ -955,6 +955,45 @@ class Nc_to_mmd(object):
 
         return data
 
+    def get_operational_status(self, mmd_element, ncin):
+        """ Get the operational_status from the processing_level ACDD
+        attribute.
+        """
+        VALID = [
+            "Operational",
+            "Pre-Operational",
+            "Experimental",
+            "Scientific",
+            "Not available"
+        ]
+        repetition_allowed = mmd_element.pop('maxOccurs', '') not in ['0', '1']
+        if repetition_allowed:
+            raise ValueError("This is not expected...")
+        acdd = mmd_element["acdd"]
+        acdd_key = list(acdd.keys())[0]
+        if acdd_key in ncin.ncattrs():
+            ostatus = ncin.getncattr(acdd_key)
+        else:
+            ostatus = "Not available"
+
+        operational_status = ""
+        valid_statuses = [v.lower() for v in VALID]
+        if ostatus.lower() not in valid_statuses:
+            self.missing_attributes['errors'].append(
+                    "The ACDD attribute 'operational_status' must "
+                    "follow a controlled vocabulary from MMD (see "
+                    "https://htmlpreview.github.io/?https://github."
+                    "com/metno/mmd/blob/master/doc/mmd-specification."
+                    "html#operational-status).")
+        else:
+            # Need to make a new list of lists to use the filter
+            # function for comparison between ostatus and valid
+            # operational_status'es from the controlled vocabulary
+            xx = [[ostatus, tt] for tt in VALID]
+            x = filter(lambda a: a[0].lower() == a[1].lower(), xx)
+            operational_status = list(x)[0][1]
+        return operational_status
+
     def get_related_information(self, mmd_element, ncin):
         """ Get related information stored in the netcdf attribute
         references.
@@ -1280,6 +1319,11 @@ class Nc_to_mmd(object):
             file_for_checksum_calculation = self.netcdf_product
 
         file_size = pathlib.Path(file_for_checksum_calculation).stat().st_size / (1024 * 1024)
+
+        # ACDD processing_level follows a controlled vocabulary, so
+        # it must be handled separately
+        self.metadata['operational_status'] = self.get_operational_status(
+            mmd_yaml.pop('operational_status'), ncin)
 
         for key in mmd_yaml:
             self.metadata[key] = self.get_acdd_metadata(mmd_yaml[key], ncin, key)

--- a/tests/test_nc_to_mmd.py
+++ b/tests/test_nc_to_mmd.py
@@ -138,7 +138,7 @@ class TestNCAttrsFromYaml(unittest.TestCase):
             'comment': 'Optional',
             'default': '',
             'description':
-                'A textual description of the processing (or quality control) '
+                'A textual description of the processing '
                 'level of the data. Valid keywords are listed in '
                 'https://htmlpreview.github.io/?https://github.com/metno/mmd/blob/'
                 'master/doc/mmd-specification.html#operational-status[Section '

--- a/tests/test_nc_to_mmd.py
+++ b/tests/test_nc_to_mmd.py
@@ -14,6 +14,7 @@ import tempfile
 import yaml
 import warnings
 import unittest
+import pytest
 
 from dateutil.parser import isoparse
 from filehash import FileHash
@@ -31,6 +32,34 @@ from py_mmd_tools.yaml_to_adoc import set_attribute
 from py_mmd_tools.yaml_to_adoc import set_attributes
 
 warnings.simplefilter("ignore", ResourceWarning)
+
+
+@pytest.mark.script
+def test_get_operational_status(dataDir, monkeypatch):
+    mmd_yaml = yaml.load(
+        resource_string("py_mmd_tools", "mmd_elements.yaml"), Loader=yaml.FullLoader
+    )
+    mmd_element = mmd_yaml["operational_status"]
+    test_in = os.path.join(dataDir, "reference_nc.nc")
+    md = Nc_to_mmd(test_in, check_only=True)
+    ncin = Dataset(test_in, "w", diskless=True)
+
+    # processing_level is not present
+    value = md.get_operational_status(mmd_element, ncin)
+    assert value == "Not available"
+
+    # processing_level is not valid
+    ncin.processing_level = "kjhhas"
+    mmd_element["maxOccurs"] = "1"
+    value = md.get_operational_status(mmd_element, ncin)
+    assert "The ACDD attribute 'operational_status' must " in md.missing_attributes['errors'][0]
+
+    # repetition of processing_level is allowed
+    mmd_element["maxOccurs"] = "unbounded"
+    with pytest.raises(ValueError) as ve:
+        value = md.get_operational_status(mmd_element, ncin)
+    assert str(ve.value) == "This is not expected..."
+    
 
 
 class TestNCAttrsFromYaml(unittest.TestCase):

--- a/tests/test_nc_to_mmd.py
+++ b/tests/test_nc_to_mmd.py
@@ -59,7 +59,6 @@ def test_get_operational_status(dataDir, monkeypatch):
     with pytest.raises(ValueError) as ve:
         value = md.get_operational_status(mmd_element, ncin)
     assert str(ve.value) == "This is not expected..."
-    
 
 
 class TestNCAttrsFromYaml(unittest.TestCase):


### PR DESCRIPTION
**Summary**: see #245 

**Related issue**: closes #245 

**Suggested reviewer(s)**:

**Reviewer checklist**:

- [ ] The headers of all files contain a reference to the repository license (i.e., "License: This file is part of py-mmd-tools, licensed under the Apache License 2.0 (https://www.apache.org/licenses/LICENSE-2.0)")
- [ ] 100% test coverage of new code - meaning:
    - [ ] The overall test coverage increased or remained the same as before
    - [ ] Every function is accompanied with a test suite
    - [ ] Tests are both positive (testing that the function work as intended with valid data) and negative (testing that the function behaves as expected with invalid data, e.g., that correct exceptions are thrown)
    - [ ] Functions with optional arguments have separate tests for all options
- [ ] Examples are supported by doctests
- [ ] All tests are passing
- [ ] All names (e.g., files, classes, functions, variables) are explicit
- [ ] Documentation (as docstrings) is complete and understandable

The checklist is based on the S-ENDA conventions and definition of done (see https://s-enda-documentation.readthedocs.io/en/latest/general_conventions.html). The above points are not necessarily relevant to all contributions. In that case, please add a short explanation to help the reviewer.
