### PR TITLE
Use search_lowercase for the MMDGroup

### DIFF
--- a/py_mmd_tools/nc_to_mmd.py
+++ b/py_mmd_tools/nc_to_mmd.py
@@ -975,7 +975,7 @@ class Nc_to_mmd(object):
             ostatus = "Not available"
 
         # If not given, search for Not available will return Not available
-        ostatus_result = self.operational_status.search(ostatus)
+        ostatus_result = self.operational_status.search_lowercase(ostatus)
         operational_status = ostatus_result.get("Short_Name", "")
 
         if operational_status == "":


### PR DESCRIPTION
**Summary**: Fixes search for operational status to accept "not available" as "Not available" and similar for other in the controlled vocabulary: https://vocab.met.no/mmd/Operational_Status 

**Related issue**:  #245 

**Suggested reviewer(s)**: @mortenwh 

**Reviewer checklist**:

- [ ] The headers of all files contain a reference to the repository license (i.e., "License: This file is part of py-mmd-tools, licensed under the Apache License 2.0 (https://www.apache.org/licenses/LICENSE-2.0)")
- [ ] 100% test coverage of new code - meaning:
    - [ ] The overall test coverage increased or remained the same as before
    - [ ] Every function is accompanied with a test suite
    - [ ] Tests are both positive (testing that the function work as intended with valid data) and negative (testing that the function behaves as expected with invalid data, e.g., that correct exceptions are thrown)
    - [ ] Functions with optional arguments have separate tests for all options
- [ ] Examples are supported by doctests
- [ ] All tests are passing
- [ ] All names (e.g., files, classes, functions, variables) are explicit
- [ ] Documentation (as docstrings) is complete and understandable

The checklist is based on the S-ENDA conventions and definition of done (see https://s-enda-documentation.readthedocs.io/en/latest/general_conventions.html). The above points are not necessarily relevant to all contributions. In that case, please add a short explanation to help the reviewer.
