### PR TITLE
Added test and raise an error if not the related_dataset relation par…

### DIFF
--- a/py_mmd_tools/nc_to_mmd.py
+++ b/py_mmd_tools/nc_to_mmd.py
@@ -907,7 +907,15 @@ class Nc_to_mmd(object):
         # TODO: use if-test and raise exception instead:
         assert len(relation_types) == len(ids)
         data = []
+        ns_re_pattern = re.compile(r"\w+\..+:")
+
         for i in range(len(ids)):
+            identifier = ids[i]
+            if re.search(ns_re_pattern, identifier) is None:
+                self.missing_attributes['errors'].append(
+                    '%s ACDD attribute is missing naming_authority in the identifier, relation %s.' % (acdd_ext_id_key, relation_types[i])
+                )
+                # NOTE: Should we return the data here, or let the data append the wrong id?
             data.append({
                 'id': ids[i],
                 'relation_type': relation_types[i],

--- a/py_mmd_tools/nc_to_mmd.py
+++ b/py_mmd_tools/nc_to_mmd.py
@@ -913,7 +913,8 @@ class Nc_to_mmd(object):
             identifier = ids[i]
             if re.search(ns_re_pattern, identifier) is None:
                 self.missing_attributes['errors'].append(
-                    '%s ACDD attribute is missing naming_authority in the identifier, relation %s.' % (acdd_ext_id_key, relation_types[i])
+                    '%s ACDD attribute is missing naming_authority in the identifier, relation %s.'
+                    % (acdd_ext_id_key, relation_types[i])
                 )
                 # NOTE: Should we return the data here, or let the data append the wrong id?
             data.append({

--- a/py_mmd_tools/script/nc2mmd.py
+++ b/py_mmd_tools/script/nc2mmd.py
@@ -127,7 +127,6 @@ def _main():  # pragma: no cover
         print(e)
 
 
-
 if __name__ == '__main__':  # pragma: no cover
     try:
         main(create_parser().parse_args())

--- a/py_mmd_tools/script/nc2mmd.py
+++ b/py_mmd_tools/script/nc2mmd.py
@@ -127,6 +127,7 @@ def _main():  # pragma: no cover
         print(e)
 
 
+
 if __name__ == '__main__':  # pragma: no cover
     try:
         main(create_parser().parse_args())

--- a/py_mmd_tools/script/nc2mmd.py
+++ b/py_mmd_tools/script/nc2mmd.py
@@ -119,8 +119,17 @@ def main(args=None):
 
 
 def _main():  # pragma: no cover
-    main(create_parser().parse_args())  # entry point in setup.cfg
-
+    try:
+        main(create_parser().parse_args())  # entry point in setup.cfg
+    except ValueError as e:
+        print(e)
+    except AttributeError as e:
+        print(e)
 
 if __name__ == '__main__':  # pragma: no cover
-    main(create_parser().parse_args())
+    try:
+        main(create_parser().parse_args())
+    except ValueError as e:
+        print(e)
+    except AttributeError as e:
+        print(e)

--- a/py_mmd_tools/script/nc2mmd.py
+++ b/py_mmd_tools/script/nc2mmd.py
@@ -126,6 +126,7 @@ def _main():  # pragma: no cover
     except AttributeError as e:
         print(e)
 
+
 if __name__ == '__main__':  # pragma: no cover
     try:
         main(create_parser().parse_args())


### PR DESCRIPTION
…ent identifier is not on the form ns:uuid as discussed in the #242 issue

**Summary**:

**Related issue**: 

**Suggested reviewer(s)**:

**Reviewer checklist**:

- [ ] The headers of all files contain a reference to the repository license (i.e., "License: This file is part of py-mmd-tools, licensed under the Apache License 2.0 (https://www.apache.org/licenses/LICENSE-2.0)")
- [ ] 100% test coverage of new code - meaning:
    - [ ] The overall test coverage increased or remained the same as before
    - [ ] Every function is accompanied with a test suite
    - [ ] Tests are both positive (testing that the function work as intended with valid data) and negative (testing that the function behaves as expected with invalid data, e.g., that correct exceptions are thrown)
    - [ ] Functions with optional arguments have separate tests for all options
- [ ] Examples are supported by doctests
- [ ] All tests are passing
- [ ] All names (e.g., files, classes, functions, variables) are explicit
- [ ] Documentation (as docstrings) is complete and understandable

The checklist is based on the S-ENDA conventions and definition of done (see https://s-enda-documentation.readthedocs.io/en/latest/general_conventions.html). The above points are not necessarily relevant to all contributions. In that case, please add a short explanation to help the reviewer.
