### PR TITLE
#264: no need for required absolute file path

### DIFF
--- a/py_mmd_tools/nc_to_mmd.py
+++ b/py_mmd_tools/nc_to_mmd.py
@@ -131,11 +131,9 @@ class Nc_to_mmd(object):
             raise ValueError(
                 "The opendap_url and output_file input parameters "
                 "must be provided if check_only is False")
-        if not os.path.isabs(netcdf_file):
-            raise ValueError("The path to the NetCDF-CF file must be absolute.")
         super(Nc_to_mmd, self).__init__()
         self.output_file = output_file
-        self.netcdf_file = netcdf_file
+        self.netcdf_file = os.path.abspath(netcdf_file)
         self.opendap_url = opendap_url
         self.check_only = check_only
         self.missing_attributes = {

--- a/tests/test_nc_to_mmd.py
+++ b/tests/test_nc_to_mmd.py
@@ -253,9 +253,8 @@ def test_get_data_access_dict(monkeypatch):
 @pytest.mark.py_mmd_tools
 def test_not_absolute_path():
     fn = 'tests/data/reference_nc.nc'
-    with pytest.raises(ValueError) as ve:
-        Nc_to_mmd(fn, check_only=True)
-    assert str(ve.value) == "The path to the NetCDF-CF file must be absolute."
+    md = Nc_to_mmd(fn, check_only=True)
+    assert os.path.isabs(md.netcdf_file) is True
 
 
 @pytest.mark.script


### PR DESCRIPTION
**Summary**: closes #264 

**Related issue**: 

**Suggested reviewer(s)**:

**Reviewer checklist**:

- [ ] The headers of all files contain a reference to the repository license (i.e., "License: This file is part of py-mmd-tools, licensed under the Apache License 2.0 (https://www.apache.org/licenses/LICENSE-2.0)")
- [ ] 100% test coverage of new code - meaning:
    - [ ] The overall test coverage increased or remained the same as before
    - [ ] Every function is accompanied with a test suite
    - [ ] Tests are both positive (testing that the function work as intended with valid data) and negative (testing that the function behaves as expected with invalid data, e.g., that correct exceptions are thrown)
    - [ ] Functions with optional arguments have separate tests for all options
- [ ] Examples are supported by doctests
- [ ] All tests are passing
- [ ] All names (e.g., files, classes, functions, variables) are explicit
- [ ] Documentation (as docstrings) is complete and understandable

The checklist is based on the S-ENDA conventions and definition of done (see https://s-enda-documentation.readthedocs.io/en/latest/general_conventions.html). The above points are not necessarily relevant to all contributions. In that case, please add a short explanation to help the reviewer.
