### PR TITLE
dirty solution to make it compatible with old files 

### DIFF
--- a/py_mmd_tools/nc_to_mmd.py
+++ b/py_mmd_tools/nc_to_mmd.py
@@ -391,11 +391,15 @@ class Nc_to_mmd(object):
                 dc['data_center_name']['long_name'] = ri[0].strip()
                 dc['data_center_name']['short_name'] = ri[1][:-1]
             else:
-                self.missing_attributes['errors'].append(
-                    "%s must be formed as <institution long name> (<institution short name>). "
-                    "Both are required attributes." % acdd_institution_key
-                )
-                continue
+                try:
+                    dc['data_center_name']['long_name'] = institutions[i]
+                    dc['data_center_name']['short_name'] = ncin.institution_short_name
+                except Exception:
+                    self.missing_attributes['errors'].append(
+                        "%s must be formed as <institution long name> (<institution short name>). "
+                        "Both are required attributes." % acdd_institution_key
+                    )
+                    continue
             data.append(dc)
         return data
 


### PR DESCRIPTION
that had institution_short_name, tested with /lustre/storeB/immutable/archive/projects/metproduction/DNMI_AROME_ARCTIC/2023/10/20/arome_arctic_lagged_12_h_subset_2_5km_20231020T18Z.nc only

fixes #279


**Summary**:

**Related issue**: 

**Suggested reviewer(s)**:

**Reviewer checklist**:

- [ ] The headers of all files contain a reference to the repository license (i.e., "License: This file is part of py-mmd-tools, licensed under the Apache License 2.0 (https://www.apache.org/licenses/LICENSE-2.0)")
- [ ] 100% test coverage of new code - meaning:
    - [ ] The overall test coverage increased or remained the same as before
    - [ ] Every function is accompanied with a test suite
    - [ ] Tests are both positive (testing that the function work as intended with valid data) and negative (testing that the function behaves as expected with invalid data, e.g., that correct exceptions are thrown)
    - [ ] Functions with optional arguments have separate tests for all options
- [ ] Examples are supported by doctests
- [ ] All tests are passing
- [ ] All names (e.g., files, classes, functions, variables) are explicit
- [ ] Documentation (as docstrings) is complete and understandable

The checklist is based on the S-ENDA conventions and definition of done (see https://s-enda-documentation.readthedocs.io/en/latest/general_conventions.html). The above points are not necessarily relevant to all contributions. In that case, please add a short explanation to help the reviewer.
