### PR TITLE
#347: switch to using variable names as wms layers

### DIFF
--- a/py_mmd_tools/nc_to_mmd.py
+++ b/py_mmd_tools/nc_to_mmd.py
@@ -1914,7 +1914,7 @@ class Nc_to_mmd(object):
         all_netcdf_variables = []
         for var in ncin.variables:
             if "standard_name" in ncin.variables[var].ncattrs():
-                all_netcdf_variables.append(ncin.variables[var].standard_name)
+                all_netcdf_variables.append(ncin.variables[var].name)
         data_accesses = [
             {
                 "type": "OPeNDAP",

--- a/tests/test_nc_to_mmd.py
+++ b/tests/test_nc_to_mmd.py
@@ -352,8 +352,8 @@ def test_get_data_access_dict_with_custom_wms(monkeypatch):
                                        wms_link='http://test-link')
     assert data[1]['type'] == 'OGC WMS'
     assert 'http://test-link' in str(data[1]['resource'])
-    assert data[1]['wms_layers'] == ['toa_bidirectional_reflectance',
-                                     'toa_bidirectional_reflectance']
+    assert data[1]['wms_layers'] == ['M01',
+                                     'M01_copy']
 
 
 @pytest.mark.py_mmd_tools


### PR DESCRIPTION
**Summary**: closes #347 

**Related issue**: 

**Suggested reviewer(s)**:

**Reviewer checklist**:

- [ ] The headers of all files contain a reference to the repository license (i.e., "License: This file is part of py-mmd-tools, licensed under the Apache License 2.0 (https://www.apache.org/licenses/LICENSE-2.0)")
- [ ] 100% test coverage of new code - meaning:
    - [ ] The overall test coverage increased or remained the same as before
    - [ ] Every function is accompanied with a test suite
    - [ ] Tests are both positive (testing that the function work as intended with valid data) and negative (testing that the function behaves as expected with invalid data, e.g., that correct exceptions are thrown)
    - [ ] Functions with optional arguments have separate tests for all options
- [ ] Examples are supported by doctests
- [ ] All tests are passing
- [ ] All names (e.g., files, classes, functions, variables) are explicit
- [ ] Documentation (as docstrings) is complete and understandable

The checklist is based on the S-ENDA conventions and definition of done (see https://s-enda-documentation.readthedocs.io/en/latest/general_conventions.html). The above points are not necessarily relevant to all contributions. In that case, please add a short explanation to help the reviewer.
