### PR TITLE
Fix floating-point precision artifacts in longitude normalization

### DIFF
--- a/py_mmd_tools/nc_to_mmd.py
+++ b/py_mmd_tools/nc_to_mmd.py
@@ -1255,10 +1255,14 @@ class Nc_to_mmd(object):
                     self.missing_attributes["errors"].append(
                         "%s must be convertible to float type." % acdd_key
                     )
-        # Make sure longitudes are within +/-180 degrees
+        # Make sure longitudes are within +/-180 degrees, preserving original
+        # string precision to avoid floating-point representation artifacts.
         if not fail:
-            data["east"] = str((float(data["east"]) + 180.) % 360. - 180.)
-            data["west"] = str((float(data["west"]) + 180.) % 360. - 180.)
+            for key in ("east", "west"):
+                val_str = str(data[key])
+                decimal_places = len(val_str.split(".")[-1]) if "." in val_str else 0
+                normalized = (float(val_str) + 180.) % 360. - 180.
+                data[key] = str(round(normalized, decimal_places))
 
         return data
 

--- a/tests/test_nc_to_mmd.py
+++ b/tests/test_nc_to_mmd.py
@@ -1192,6 +1192,27 @@ class TestNC2MMD(unittest.TestCase):
         self.assertIsInstance(value["north"], str)
         self.assertIsInstance(value["south"], str)
 
+    def test_geographic_extent_no_float_precision_artifacts(self):
+        """Test that longitude normalization does not introduce floating-point
+        precision artifacts. E.g., input '41.76' should remain '41.76', not
+        become '41.75999999999999'.
+        """
+        mmd_yaml = yaml.load(
+            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+        )
+        md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
+        ncin = Dataset(md.netcdf_file, "w", diskless=True)
+        ncin.geospatial_lat_max = "60.158733"
+        ncin.geospatial_lat_min = "59.78492"
+        ncin.geospatial_lon_max = "41.76"
+        ncin.geospatial_lon_min = "10.5"
+        value = md.get_geographic_extent_rectangle(
+            mmd_yaml['geographic_extent']['rectangle'], ncin)
+        self.assertEqual(value["east"], "41.76")
+        self.assertEqual(value["west"], "10.5")
+        self.assertEqual(value["north"], "60.158733")
+        self.assertEqual(value["south"], "59.78492")
+
     def test_geographic_extent_rectangle_is_floatable(self):
         """ Test that the provided geospatial coordinates can be
         converted to float.


### PR DESCRIPTION
When normalizing longitudes to ±180°, float arithmetic produced representation artifacts (e.g. '41.76' → '41.75999999999999'). Fix by rounding back to the original number of decimal places.

Also handles numpy.float64 inputs by converting to str before inspecting decimal places.

**Summary**: closes #358 

**Related issue**: #358 

**Suggested reviewer(s)**:

**Reviewer checklist**:

- [ ] The headers of all files contain a reference to the repository license (i.e., "License: This file is part of py-mmd-tools, licensed under the Apache License 2.0 (https://www.apache.org/licenses/LICENSE-2.0)")
- [ ] 100% test coverage of new code - meaning:
    - [ ] The overall test coverage increased or remained the same as before
    - [ ] Every function is accompanied with a test suite
    - [ ] Tests are both positive (testing that the function work as intended with valid data) and negative (testing that the function behaves as expected with invalid data, e.g., that correct exceptions are thrown)
    - [ ] Functions with optional arguments have separate tests for all options
- [ ] Examples are supported by doctests
- [ ] All tests are passing
- [ ] All names (e.g., files, classes, functions, variables) are explicit
- [ ] Documentation (as docstrings) is complete and understandable

The checklist is based on the S-ENDA conventions and definition of done (see https://s-enda-documentation.readthedocs.io/en/latest/general_conventions.html). The above points are not necessarily relevant to all contributions. In that case, please add a short explanation to help the reviewer.
