### PR TITLE
Fix Python 3.12 compatibility

### DIFF
--- a/.github/workflows/syntax.yml
+++ b/.github/workflows/syntax.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Python Setup
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
           architecture: x64
       - name: Checkout Source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install flake8
         run: pip install flake8
       - name: Syntax Error Check

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -7,7 +7,7 @@ jobs:
   tagpr:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: Songmu/tagpr@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,16 +10,16 @@ jobs:
   pyTestCov:
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     runs-on: ubuntu-latest
     steps:
       - name: Python Setup
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
       - name: Checkout Source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Dependencies
         run: |
           pip install --upgrade pip
@@ -32,7 +32,7 @@ jobs:
           git clone https://github.com/metno/mmd $MMD_PATH
           python -m pytest -v --cov=py_mmd_tools --cov=script --timeout=120
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: true
           flags: unittests # optional

--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,5 @@ dmypy.json
 
 # Custom
 /*.nc
+issue358.md
+summary.md

--- a/py_mmd_tools/mmd_elements.yaml
+++ b/py_mmd_tools/mmd_elements.yaml
@@ -365,6 +365,7 @@ storage_information:
   file_size:
   checksum:
   storage_expiry_date:
+  responsible_unit:
 
 related_information:
   maxOccurs: unbounded

--- a/py_mmd_tools/mmd_to_nc.py
+++ b/py_mmd_tools/mmd_to_nc.py
@@ -16,7 +16,7 @@ import yaml
 import netCDF4 as nc
 import lxml.etree as ET
 import py_mmd_tools
-from pkg_resources import resource_string
+from importlib.resources import files
 
 
 class Mmd_to_nc(object):
@@ -40,7 +40,7 @@ class Mmd_to_nc(object):
         self.namespaces.update({'xml': 'http://www.w3.org/XML/1998/namespace'})
         # Translation file between MMD and ACDD
         self.mmd_yaml = yaml.load(
-            resource_string(py_mmd_tools.__name__, 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files(py_mmd_tools.__name__).joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         # Dictionary that will contain all ACDD attributes
         self.acdd_metadata = None

--- a/py_mmd_tools/mmd_to_nc.py
+++ b/py_mmd_tools/mmd_to_nc.py
@@ -40,7 +40,8 @@ class Mmd_to_nc(object):
         self.namespaces.update({'xml': 'http://www.w3.org/XML/1998/namespace'})
         # Translation file between MMD and ACDD
         self.mmd_yaml = yaml.load(
-            files(py_mmd_tools.__name__).joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
+            files(py_mmd_tools.__name__).joinpath('mmd_elements.yaml').read_bytes(),
+            Loader=yaml.FullLoader
         )
         # Dictionary that will contain all ACDD attributes
         self.acdd_metadata = None

--- a/py_mmd_tools/nc_to_mmd.py
+++ b/py_mmd_tools/nc_to_mmd.py
@@ -27,7 +27,7 @@ import numpy as np
 
 from filehash import FileHash
 from itertools import zip_longest
-from pkg_resources import resource_string
+from importlib.resources import files
 from dateutil.parser import isoparse
 from uuid import UUID
 
@@ -1709,7 +1709,7 @@ class Nc_to_mmd(object):
         # Get list of MMD elements
         if mmd_yaml is None:
             mmd_yaml = yaml.load(
-                resource_string(self.__module__.split(".")[0], "mmd_elements.yaml"),
+                files(self.__module__.split(".")[0]).joinpath("mmd_elements.yaml").read_bytes(),
                 Loader=yaml.FullLoader,
             )
 

--- a/py_mmd_tools/script/nc2mmd.py
+++ b/py_mmd_tools/script/nc2mmd.py
@@ -24,7 +24,7 @@ import pathlib
 import yaml
 import warnings
 
-from pkg_resources import resource_string
+from importlib.resources import files
 
 from py_mmd_tools import nc_to_mmd
 
@@ -145,7 +145,7 @@ def main(args=None):
         if args.file_location is not None:
             overrides = {"file_location": args.file_location}
         mmd_yaml = yaml.load(
-            resource_string(md.__module__.split(".")[0], "mmd_elements.yaml"),
+            files(md.__module__.split(".")[0]).joinpath("mmd_elements.yaml").read_bytes(),
             Loader=yaml.FullLoader
         )
         metadata_id = md.get_metadata_identifier(mmd_yaml["metadata_identifier"],

--- a/py_mmd_tools/yaml_to_adoc.py
+++ b/py_mmd_tools/yaml_to_adoc.py
@@ -1,7 +1,7 @@
 import yaml
 import jinja2
 
-from pkg_resources import resource_string
+from importlib.resources import files
 
 
 def repetition_allowed(field):
@@ -130,15 +130,11 @@ def nc_attrs_from_yaml():
     defined as ACDD extensions.
     """
     mmd_yaml = yaml.load(
-        resource_string(
-            globals()['__name__'].split('.')[0], 'mmd_elements.yaml'
-        ), Loader=yaml.FullLoader
+        files(globals()['__name__'].split('.')[0]).joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
     )
 
     cf_yaml = yaml.load(
-        resource_string(
-            globals()['__name__'].split('.')[0], 'cf_elements.yaml'
-        ), Loader=yaml.FullLoader
+        files(globals()['__name__'].split('.')[0]).joinpath('cf_elements.yaml').read_bytes(), Loader=yaml.FullLoader
     )
 
     attributes = {}

--- a/py_mmd_tools/yaml_to_adoc.py
+++ b/py_mmd_tools/yaml_to_adoc.py
@@ -130,11 +130,13 @@ def nc_attrs_from_yaml():
     defined as ACDD extensions.
     """
     mmd_yaml = yaml.load(
-        files(globals()['__name__'].split('.')[0]).joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
+        files(globals()['__name__'].split('.')[0]).joinpath('mmd_elements.yaml').read_bytes(),
+        Loader=yaml.FullLoader
     )
 
     cf_yaml = yaml.load(
-        files(globals()['__name__'].split('.')[0]).joinpath('cf_elements.yaml').read_bytes(), Loader=yaml.FullLoader
+        files(globals()['__name__'].split('.')[0]).joinpath('cf_elements.yaml').read_bytes(),
+        Loader=yaml.FullLoader
     )
 
     attributes = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,10 +12,10 @@ classifiers = [
 	"License :: OSI Approved :: Apache Software License",
 	"Operating System :: OS Independent",
 	"Programming Language :: Python :: 3 :: Only",
-	"Programming Language :: Python :: 3.8",
 	"Programming Language :: Python :: 3.9",
 	"Programming Language :: Python :: 3.10",
 	"Programming Language :: Python :: 3.11",
+	"Programming Language :: Python :: 3.12",
 	"Programming Language :: Python :: Implementation :: CPython",
 	"Topic :: Scientific/Engineering",
 	"Topic :: Scientific/Engineering :: Atmospheric Science",
@@ -26,7 +26,7 @@ dependencies = [
 	"filehash",
 	"jinja2",
 	"lxml>=4.5",
-	"netCDF4 ~= 1.5",
+	"netCDF4 >=1.5",
 	"pandas",
 	"parmap",
 	"pytest",
@@ -42,7 +42,7 @@ dependencies = [
 name = "py-mmd-tools"
 description = "This  is a tools for generating MMD files from netCDF-CF files with ACDD attributes, for documenting netCDF-CF files from MMD information."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 
 [project.scripts]
 nc2mmd = "py_mmd_tools.script.nc2mmd:_main"

--- a/tests/test_mmd_yaml_vs_xsd.py
+++ b/tests/test_mmd_yaml_vs_xsd.py
@@ -25,7 +25,8 @@ class TestMDDElementsInYAMLAndXSD(unittest.TestCase):
         with open(xml_file) as xml:
             self.mmd_xml = xmltodict.parse(xml.read())
         self.mmd_yaml = yaml.load(
-            files(py_mmd_tools.__name__).joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
+            files(py_mmd_tools.__name__).joinpath('mmd_elements.yaml').read_bytes(),
+            Loader=yaml.FullLoader
         )
 
     def check_elements(self, elements, type_defs=None):

--- a/tests/test_mmd_yaml_vs_xsd.py
+++ b/tests/test_mmd_yaml_vs_xsd.py
@@ -14,7 +14,7 @@ import xmltodict
 import unittest
 import py_mmd_tools
 
-from pkg_resources import resource_string
+from importlib.resources import files
 
 
 class TestMDDElementsInYAMLAndXSD(unittest.TestCase):
@@ -25,7 +25,7 @@ class TestMDDElementsInYAMLAndXSD(unittest.TestCase):
         with open(xml_file) as xml:
             self.mmd_xml = xmltodict.parse(xml.read())
         self.mmd_yaml = yaml.load(
-            resource_string(py_mmd_tools.__name__, 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files(py_mmd_tools.__name__).joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
 
     def check_elements(self, elements, type_defs=None):

--- a/tests/test_nc_to_mmd.py
+++ b/tests/test_nc_to_mmd.py
@@ -41,6 +41,13 @@ from tests.test_nc2mmd_script import patchedDataset
 warnings.simplefilter("ignore", ResourceWarning)
 
 
+def _mmd_yaml():
+    return yaml.load(
+        files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(),
+        Loader=yaml.FullLoader
+    )
+
+
 @pytest.mark.py_mmd_tools
 def test_parent_keyword_arg(dataDir):
     """ Test that a parent uuid can be provided to the to_mmd
@@ -139,9 +146,7 @@ def test_get_landing_page_url(dataDir):
 def test_license_missing(dataDir):
     """ Test that an error is raised if the license attribute is missing.
     """
-    mmd_yaml = yaml.load(
-        files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-    )
+    mmd_yaml = _mmd_yaml()
     # nc_to_update.nc does not have license..
     md = Nc_to_mmd(os.path.join(dataDir, "nc_to_update.nc"), check_only=True)
     md.get_license(mmd_yaml['use_constraint'], md.ncin)
@@ -181,9 +186,7 @@ def testNc_to_mmd_get_geographic_extent_polygon(dataDir):
                               "60.63 1.92, 60.59 1.47, 60.54 1.02, 60.49 0.56, 60.49 0.56, "
                               "60.33 0.64, 60.18 0.71, 60.03 0.77, 59.89 0.84, 59.74 0.90, "
                               "59.59 0.97, 59.45 1.03, 59.30 1.10, 59.15 1.16, 59.01 1.23))")
-    mmd_yaml = yaml.load(
-        files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-    )
+    mmd_yaml = _mmd_yaml()
     data = md.get_geographic_extent_polygon(mmd_yaml["geographic_extent"].pop("polygon"), ncin)
     assert data["srsName"] == "EPSG:4326"
     ncin.close()
@@ -193,9 +196,7 @@ def testNc_to_mmd_get_geographic_extent_polygon(dataDir):
 def test_get_related_dataset(dataDir):
     """ Test get_related_dataset function.
     """
-    mmd_yaml = yaml.load(
-        files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-    )
+    mmd_yaml = _mmd_yaml()
     # One related dataset
     md = Nc_to_mmd(os.path.join(dataDir, 'reference_nc.nc'), check_only=True)
     ncin = Dataset(md.netcdf_file, "w", diskless=True)
@@ -263,9 +264,7 @@ def testNc_to_mmd_Get_acdd_metadata(dataDir):
 
     is covered for the boolean True case.
     """
-    mmd_yaml = yaml.load(
-        files("py_mmd_tools").joinpath("mmd_elements.yaml").read_bytes(), Loader=yaml.FullLoader
-    )
+    mmd_yaml = _mmd_yaml()
     key = "dataset_production_status"
     test_in = os.path.join(dataDir, "reference_nc.nc")
     md = Nc_to_mmd(test_in, check_only=True)
@@ -439,9 +438,7 @@ def test_not_absolute_path():
 
 @pytest.mark.py_mmd_tools
 def test_get_operational_status(dataDir, monkeypatch):
-    mmd_yaml = yaml.load(
-        files("py_mmd_tools").joinpath("mmd_elements.yaml").read_bytes(), Loader=yaml.FullLoader
-    )
+    mmd_yaml = _mmd_yaml()
     mmd_element = mmd_yaml["operational_status"]
     test_in = os.path.join(dataDir, "reference_nc.nc")
     md = Nc_to_mmd(test_in, check_only=True)
@@ -467,9 +464,7 @@ def test_get_operational_status(dataDir, monkeypatch):
 
 @pytest.mark.py_mmd_tools
 def test_dataset_production_status(dataDir):
-    mmd_yaml = yaml.load(
-        files("py_mmd_tools").joinpath("mmd_elements.yaml").read_bytes(), Loader=yaml.FullLoader
-    )
+    mmd_yaml = _mmd_yaml()
     mmd_element = mmd_yaml["dataset_production_status"]
     test_in = os.path.join(dataDir, "reference_nc.nc")
     md = Nc_to_mmd(test_in, check_only=True)
@@ -495,9 +490,7 @@ def test_dataset_production_status(dataDir):
 
 @pytest.mark.py_mmd_tools
 def test_get_quality_control(dataDir):
-    mmd_yaml = yaml.load(
-        files("py_mmd_tools").joinpath("mmd_elements.yaml").read_bytes(), Loader=yaml.FullLoader
-    )
+    mmd_yaml = _mmd_yaml()
     mmd_element = mmd_yaml["quality_control"]
     test_in = os.path.join(dataDir, "reference_nc.nc")
     md = Nc_to_mmd(test_in, check_only=True)
@@ -677,9 +670,7 @@ class TestNCAttrsFromYaml(unittest.TestCase):
         the MMD to ACDD translations.
         """
         self.maxDiff = None
-        self.mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        self.mmd_yaml = _mmd_yaml()
         self.attributes = {}
         self.attributes['acdd'] = {}
         self.attributes['acdd']['required'] = []
@@ -945,9 +936,7 @@ class TestNC2MMD(unittest.TestCase):
         self.assertFalse(valid_url(None))
 
     def test_license__deprecated_attrs(self):
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(self.reference_nc, check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.license = "CC-BY-4.0"
@@ -960,9 +949,7 @@ class TestNC2MMD(unittest.TestCase):
             '"license_resource" is a deprecated attribute')
 
     def test_license__invalid_url(self):
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(self.reference_nc, check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.license = "spdx.org/licenses/CC-BY-4.0"
@@ -977,9 +964,7 @@ class TestNC2MMD(unittest.TestCase):
         """Test that a valid full license with both url and
         identifier is accepted and parsed correctly.
         """
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(self.reference_nc, check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.license = "http://spdx.org/licenses/CC-BY-4.0 (CC-BY-4.0)"
@@ -990,9 +975,7 @@ class TestNC2MMD(unittest.TestCase):
     def test_license__simple(self):
         """Test that a license with valid url only is accepted and parsed correctly.
         """
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(self.reference_nc, check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.license = "http://spdx.org/licenses/CC-BY-4.0"
@@ -1007,9 +990,7 @@ class TestNC2MMD(unittest.TestCase):
         """Test that a license with a valid url to an unstandard
         license causes an error.
         """
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(self.reference_nc, check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.license = "http://spdx.org/licenses/CC-BY-4.1"
@@ -1025,9 +1006,7 @@ class TestNC2MMD(unittest.TestCase):
     def test_license__according_to_adc1(self):
         """Test that a license passed as url(identifier) is accepted and parsed correctly.
         """
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(self.reference_nc, check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.license = "http://spdx.org/licenses/CC-BY-4.0(CC-BY-4.0)"
@@ -1038,9 +1017,7 @@ class TestNC2MMD(unittest.TestCase):
     def test_license__according_to_adc2(self):
         """Test that a license passed as url (identifier) is accepted and parsed correctly.
         """
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(self.reference_nc, check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.license = "http://spdx.org/licenses/CC-BY-4.0 (CC-BY-4.0)"
@@ -1052,9 +1029,7 @@ class TestNC2MMD(unittest.TestCase):
         """ Test that a license string that is not standard is added
         as license_text.
         """
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(self.reference_nc, check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.license = "https://earth.esa.int/eogateway/documents/20142/1564626/" \
@@ -1086,9 +1061,7 @@ class TestNC2MMD(unittest.TestCase):
         """ Test that a default value can be used even if no acdd
         or acdd_ext fields are present.
         """
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_acdd_metadata(
@@ -1102,9 +1075,7 @@ class TestNC2MMD(unittest.TestCase):
         error if there are several alternative acdd or acdd_ext
         fields.
         """
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
         with self.assertRaises(ValueError) as e:
@@ -1119,9 +1090,7 @@ class TestNC2MMD(unittest.TestCase):
     def test_get_acdd_metadata_uses_default_date_created_type(self):
         """Test that the get_acdd_metadata function uses default
         date_created_type."""
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_metadata_updates(mmd_yaml['last_metadata_update'], ncin)
@@ -1131,9 +1100,7 @@ class TestNC2MMD(unittest.TestCase):
         """The geospatial_bounds nc attribute may not be a proper wkt string.
         Test that this case is properly handled.
         """
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(self.fail_nc, check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.geospatial_bounds = ""
@@ -1147,9 +1114,7 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_geographic_extent_polygon(self):
         """ToDo: Add docstring"""
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_geographic_extent_polygon(
@@ -1160,9 +1125,7 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_missing_nc_attrs(self):
         """ToDo: Add docstring"""
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_missing_attrs.nc'),
                        check_only=True)
         ncin = Dataset(md.netcdf_file)
@@ -1183,9 +1146,7 @@ class TestNC2MMD(unittest.TestCase):
 
         This test checks that this translates correctly.
         """
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.geospatial_lat_max = "60.158733"
@@ -1199,9 +1160,7 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_geographic_extent_is_string(self):
         """Check that the content is actually string type."""
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.geospatial_lat_max = "60.158733"
@@ -1220,9 +1179,7 @@ class TestNC2MMD(unittest.TestCase):
         precision artifacts. E.g., input '41.76' should remain '41.76', not
         become '41.75999999999999'.
         """
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.geospatial_lat_max = "60.158733"
@@ -1240,9 +1197,7 @@ class TestNC2MMD(unittest.TestCase):
         """ Test that the provided geospatial coordinates can be
         converted to float.
         """
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.geospatial_lat_max = "60.158733f; // float"
@@ -1259,9 +1214,7 @@ class TestNC2MMD(unittest.TestCase):
         """Test that the geographic extent rectangle can be added
         as a kwarg.
         """
-        yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        _mmd_yaml()
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_missing_rectangle.nc'),
                        check_only=True)
         md.to_mmd(overrides={
@@ -1300,9 +1253,7 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_abstract(self):
         """ToDo: Add docstring"""
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_abstracts(mmd_yaml['abstract'], ncin)
@@ -1312,9 +1263,7 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_title(self):
         """ToDo: Add docstring"""
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_titles(mmd_yaml['title'], ncin)
@@ -1329,9 +1278,7 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_title_one_language_only(self):
         """ToDo: Add docstring"""
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_id_missing.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_titles(mmd_yaml['title'], ncin)
@@ -1344,9 +1291,7 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_data_center(self):
         """Test get_data_centers function"""
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_data_centers(mmd_yaml['data_center'], ncin)
@@ -1361,7 +1306,7 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_data_access(self):
         """ToDo: Add docstring"""
-        yaml.load(files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader)
+        _mmd_yaml()
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         Dataset(md.netcdf_file)
         value = None
@@ -1369,9 +1314,7 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_dataset_production_status(self):
         """ToDo: Add docstring"""
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_acdd_metadata(
@@ -1384,9 +1327,7 @@ class TestNC2MMD(unittest.TestCase):
         when alternate_identifier is no present in the global
         attributes of the nc-file.
         """
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_alternate_identifier(mmd_yaml['alternate_identifier'], ncin)
@@ -1396,9 +1337,7 @@ class TestNC2MMD(unittest.TestCase):
         """Test that an error is raised when the alternate_identifier
         is missing the type between parentheses.
         """
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_with_altID.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.alternate_identifier = 'wrong format, missing type'
@@ -1415,9 +1354,7 @@ class TestNC2MMD(unittest.TestCase):
         """Test that MMD alternate_identifier is equal to the one
         provided in the nc-file.
         """
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_with_altID.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_alternate_identifier(
@@ -1430,9 +1367,7 @@ class TestNC2MMD(unittest.TestCase):
         """Test that MMD alternate_identifier is equal to the ones
         provided in the nc-file.
         """
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_with_altID_multiple.nc'),
                        check_only=True)
         ncin = Dataset(md.netcdf_file)
@@ -1445,9 +1380,7 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_metadata_status_is_active(self):
         """ToDo: Add docstring"""
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_acdd_metadata(mmd_yaml['metadata_status'], ncin, 'metadata_status')
@@ -1455,9 +1388,7 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_last_metadata_update(self):
         """ToDo: Add docstring"""
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_metadata_updates(mmd_yaml['last_metadata_update'], ncin)
@@ -1465,9 +1396,7 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_use_defaults_for_personnel(self):
         """ToDo: Add docstring"""
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(
             os.path.abspath(os.path.abspath('tests/data/reference_nc_missing_attrs.nc')),
             check_only=True)
@@ -1480,9 +1409,7 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_missing_temporal_extent(self):
         """ToDo: Add docstring"""
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_missing_attrs.nc'),
                        check_only=True)
         ncin = Dataset(md.netcdf_file)
@@ -1495,9 +1422,7 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_missing_temporal_extent_but_start_provided_in_dict(self):
         """ToDo: Add docstring"""
-        yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        _mmd_yaml()
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_missing_attrs.nc'),
                        check_only=True)
         with self.assertRaises(AttributeError):
@@ -1507,7 +1432,7 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_missing_temporal_extent_but_start_and_end_provided_in_dict(self):
         """ToDo: Add docstring"""
-        yaml.load(files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader)
+        _mmd_yaml()
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_missing_attrs.nc'),
                        check_only=True)
         with self.assertRaises(AttributeError):
@@ -1519,7 +1444,7 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_missing_temporal_extent_but_start_and_end_provided_in_dict_and_wrong(self):
         """Test that errors are raised when input times are not iso"""
-        yaml.load(files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader)
+        _mmd_yaml()
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_missing_attrs.nc'),
                        check_only=True)
         with self.assertRaises(AttributeError):
@@ -1538,9 +1463,7 @@ class TestNC2MMD(unittest.TestCase):
         """Test that two start dates are handled correctly in the
         translation to MMD.
         """
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_attrs_multiple.nc'),
                        check_only=True)
         ncin = Dataset(md.netcdf_file)
@@ -1555,9 +1478,7 @@ class TestNC2MMD(unittest.TestCase):
         """Test that two start dates are handled correctly in the
         translation to MMD.
         """
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_attrs_multiple.nc'),
                        check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
@@ -1620,9 +1541,7 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_temporal_extent(self):
         """ToDo: Add docstring"""
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_temporal_extents(mmd_yaml['temporal_extent'], ncin)
@@ -1633,9 +1552,7 @@ class TestNC2MMD(unittest.TestCase):
         """Test that an error is raised if the creator_* attributes
         don't have the same number of comma separated entries.
         """
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(
             os.path.abspath('tests/data/reference_nc_attrs_multiple_mixed_creator.nc'),
             check_only=True
@@ -1651,9 +1568,7 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_personnel_multiple(self):
         """ToDo: Add docstring"""
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_attrs_multiple.nc'),
                        check_only=True)
         ncin = Dataset(md.netcdf_file)
@@ -1667,9 +1582,7 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_personnel_multiple_creator_and_contributor(self):
         """Test that we can have multiple people in MMD personnel field"""
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(
             os.path.abspath('tests/data/reference_nc_attrs_multiple_and_contributor.nc'),
             check_only=True
@@ -1691,9 +1604,7 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_personnel_acdd_roles_not_list(self):
         """Test that we can have multiple people in MMD personnel field"""
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(
             os.path.abspath('tests/data/reference_nc_attrs_multiple_and_contributor.nc'),
             check_only=True
@@ -1710,9 +1621,7 @@ class TestNC2MMD(unittest.TestCase):
         self.assertEqual(value[1]['organisation'], 'Norwegian Meteorological Institute')
 
     def test_get_personnel_role_invalid(self):
-        mmd_yaml = yaml.load(
-            files("py_mmd_tools").joinpath("mmd_elements.yaml").read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         mmd_element = mmd_yaml["personnel"]
         test_in = os.path.abspath('tests/data/reference_nc.nc')
         md = Nc_to_mmd(test_in, check_only=True)
@@ -1725,9 +1634,7 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_personnel(self):
         """Test reading of personnel from nc file into MMD"""
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_personnel(mmd_yaml['personnel'], ncin)
@@ -1735,9 +1642,7 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_iso_topic_category(self):
         """ToDo: Add docstring"""
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_acdd_metadata(
@@ -1748,9 +1653,7 @@ class TestNC2MMD(unittest.TestCase):
         self.assertEqual(value[2], 'oceans')
 
     def test_get_iso_topic_category_invalid(self):
-        mmd_yaml = yaml.load(
-            files("py_mmd_tools").joinpath("mmd_elements.yaml").read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         mmd_element = mmd_yaml["iso_topic_category"]
         test_in = os.path.abspath('tests/data/reference_nc.nc')
         md = Nc_to_mmd(test_in, check_only=True)
@@ -1762,9 +1665,7 @@ class TestNC2MMD(unittest.TestCase):
         assert "The ACDD attribute 'iso_topic_category' must" in md.missing_attributes['errors'][0]
 
     def test_get_iso_topic_category_not_available(self):
-        mmd_yaml = yaml.load(
-            files("py_mmd_tools").joinpath("mmd_elements.yaml").read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         mmd_element = mmd_yaml["iso_topic_category"]
         test_in = os.path.abspath('tests/data/reference_nc.nc')
         md = Nc_to_mmd(test_in, check_only=True)
@@ -1778,9 +1679,7 @@ class TestNC2MMD(unittest.TestCase):
         """Test that an error is raised if activity_type is not a valid one, e.g. not in
         the list https://htmlpreview.github.io/?https://github.com/metno/mmd/blob/
         master/doc/mmd-specification.html#activity-type"""
-        mmd_yaml = yaml.load(
-            files("py_mmd_tools").joinpath("mmd_elements.yaml").read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         mmd_element = mmd_yaml["activity_type"]
         test_in = os.path.abspath('tests/data/reference_nc.nc')
         md = Nc_to_mmd(test_in, check_only=True)
@@ -1797,9 +1696,7 @@ class TestNC2MMD(unittest.TestCase):
         has the same name in GCMD and MMD but the resource provided
         in the netcdf file is GCMD.
         """
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_missing_keywords_vocab.nc'),
                        check_only=True)
         # The GCMD resource url
@@ -1818,9 +1715,7 @@ class TestNC2MMD(unittest.TestCase):
         the MMD vocabulary, but the instrument does not have a valid
         vocabulary url.
         """
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_missing_keywords_vocab.nc'),
                        check_only=True)
         # Define dataset
@@ -1843,9 +1738,7 @@ class TestNC2MMD(unittest.TestCase):
         vocabulary for platforms is not registered if there is no
         other valid resource url.
         """
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(self.fail_nc, check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.platform = 'Fake Environmental Satellite'
@@ -1865,9 +1758,7 @@ class TestNC2MMD(unittest.TestCase):
         However, note that one pair of parentheses is allowed in the
         long name.
         """
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(self.fail_nc, check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.platform = 'Suomi National Polar-orbiting Partnership (Suomi NPP)(Too Many)(SNPP)'
@@ -1885,9 +1776,7 @@ class TestNC2MMD(unittest.TestCase):
         not in the format
         <instrument long name>(<instrument short name>).
         """
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(self.fail_nc, check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.platform = "Suomi National Polar-orbiting Partnership (SNPP)"
@@ -1907,9 +1796,7 @@ class TestNC2MMD(unittest.TestCase):
 
         TODO: Find a platform where this is actually the case...
         """
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(self.fail_nc, check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.platform = 'Suomi National Polar-orbiting Partnership (Suomi NPP)(SNPP)'
@@ -1923,9 +1810,7 @@ class TestNC2MMD(unittest.TestCase):
     def test_instrument_name_extra_parentheses(self):
         """ Test that parentheses in the long name are allowed
         """
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(self.fail_nc, check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.platform = "Platform Name (PN)"
@@ -1941,9 +1826,7 @@ class TestNC2MMD(unittest.TestCase):
         is missing and the platform is not in
         https://vocab.met.no/mmd/en/page/Platform.
         """
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(self.fail_nc, check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
         # Note that Envisat is not in the MMD vocabulary
@@ -1965,9 +1848,7 @@ class TestNC2MMD(unittest.TestCase):
         is found in MMD and that the MMD vocabulary resource is
         provided.
         """
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_missing_keywords_vocab.nc'),
                        check_only=True)
         ncin = Dataset(md.netcdf_file)
@@ -1993,9 +1874,7 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_keywords_missing(self):
         """ToDo: Add docstring"""
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_fail.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
         md.get_keywords(mmd_yaml['keywords'], ncin)
@@ -2013,9 +1892,7 @@ class TestNC2MMD(unittest.TestCase):
         keywords_vocabulary attribute is not formatted
         as short_name:long_name:url
         """
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(self.fail_nc, check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.keywords = "GCMDSK:Earth Science > Atmosphere > Atmospheric radiation, " \
@@ -2033,9 +1910,7 @@ class TestNC2MMD(unittest.TestCase):
         """ Test that an error message is issued if the url pattern
         of a vocabulary is wrong.
         """
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(self.fail_nc, check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.keywords = "GCMDSK:Earth Science > Atmosphere > Atmospheric radiation, " \
@@ -2061,9 +1936,7 @@ class TestNC2MMD(unittest.TestCase):
         spaces around 'Meteorological geographical features' are
         removed.
         """
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(self.fail_nc, check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.keywords = "GCMDSK: Earth Science > Atmosphere > Atmospheric radiation , " \
@@ -2081,9 +1954,7 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_keywords_vocabulary_missing(self):
         """ToDo: Add docstring"""
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_missing_keywords_vocab.nc'),
                        check_only=True)
         ncin = Dataset(md.netcdf_file)
@@ -2097,9 +1968,7 @@ class TestNC2MMD(unittest.TestCase):
         """Test that an error is added if the CF standard name does
         not exist.
         """
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_non_cf_standard_name.nc'),
                        check_only=True)
         ncin = Dataset(md.netcdf_file)
@@ -2112,9 +1981,7 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_keywords(self):
         """ToDo: Add docstring"""
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_keywords(mmd_yaml['keywords'], ncin)
@@ -2140,9 +2007,7 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_keywords_multiple(self):
         """ToDo: Add docstring"""
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_attrs_multiple.nc'),
                        check_only=True)
         ncin = Dataset(md.netcdf_file)
@@ -2159,9 +2024,7 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_platforms(self):
         """ToDo: Add docstring"""
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_platforms(mmd_yaml['platform'], ncin)
@@ -2178,9 +2041,7 @@ class TestNC2MMD(unittest.TestCase):
         """Check that the general rules are followed when a
         vocabulary different from MMD is used, and that we use what
         we get."""
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_gcmd_platform.nc'),
                        check_only=True)
         ncin = Dataset(md.netcdf_file)
@@ -2200,9 +2061,7 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_projects(self):
         """Test getting project information from nc-file"""
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_projects(mmd_yaml['project'], ncin)
@@ -2210,9 +2069,7 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_projects_with_short_name(self):
         """Test getting project information with short name from nc-file"""
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_project_with_short_name.nc'),
                        check_only=True)
         ncin = Dataset(md.netcdf_file)
@@ -2222,9 +2079,7 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_projects_missing(self):
         """Test getting project information when this is missing"""
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_missing_project.nc'),
                        check_only=True)
         ncin = Dataset(md.netcdf_file)
@@ -2233,9 +2088,7 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_projects_malformed(self):
         """Test getting project information when this is malformed"""
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_malformed_project.nc'),
                        check_only=True)
         ncin = Dataset(md.netcdf_file)
@@ -2246,9 +2099,7 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_dataset_citation_missing_attrs(self):
         """Test that missing url and other is accepted"""
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_missing_keywords_vocab.nc'),
                        check_only=True)
         ncin = Dataset(md.netcdf_file)
@@ -2267,9 +2118,7 @@ class TestNC2MMD(unittest.TestCase):
             "author": "No Name",
             "publication_date": "2023-07-06",
             "title": "Some random title"}
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(self.fail_nc, check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.creator_name = "Tester Test"
@@ -2300,9 +2149,7 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_dataset_citation(self):
         """ToDo: Add docstring"""
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_dataset_citations(mmd_yaml['dataset_citation'], ncin)
@@ -2320,9 +2167,7 @@ class TestNC2MMD(unittest.TestCase):
                          'https://data.met.no/dataset/b7cb7934-77ca-4439-812e-f560df3fe7eb')
 
     def test_dataset_citation_invalid_date(self):
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.time_coverage_start = "2020-11-27T13:40:02.019817Z"
@@ -2338,9 +2183,7 @@ class TestNC2MMD(unittest.TestCase):
         # Test that an error is appended if date created is not in
         # the correct format
         ncin.date_created = "2020-99-28 13:51:24"
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         value = md.get_dataset_citations(mmd_yaml['dataset_citation'], ncin)
         self.assertIn(
             "ACDD attribute date_created contains an invalid ISO8601 date:",
@@ -2367,9 +2210,7 @@ class TestNC2MMD(unittest.TestCase):
         inconsistencies between the hardcoded acdd values, and the ones
         from mmd_elements.yaml.
         """
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         # Only one value in the list
         mmd_yaml['metadata_identifier']['acdd'] = {'id': {}}
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
@@ -2403,9 +2244,7 @@ class TestNC2MMD(unittest.TestCase):
         )
         # Change the valid naming authorities to force an error
         md.VALID_NAMING_AUTHORITIES = ['jada.no']
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md.get_metadata_identifier(mmd_yaml['metadata_identifier'], ncin)
         self.assertEqual(
             md.missing_attributes['errors'][0],
@@ -2413,9 +2252,7 @@ class TestNC2MMD(unittest.TestCase):
         )
 
     def test_to_mmd_warning_not_empty(self):
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         mmd_yaml['dummy_field'] = {}
         mmd_yaml['dummy_field']['minOccurs'] = '1'
         mmd_yaml['dummy_field']['default'] = 'test'
@@ -2435,9 +2272,7 @@ class TestNC2MMD(unittest.TestCase):
         is missing, and that the uuid validation fails for an id which
         is not an uuid.
         """
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         # The id attribute is not a uuid
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_fail.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
@@ -2458,9 +2293,7 @@ class TestNC2MMD(unittest.TestCase):
     def test_get_correct_id_from_ncfile(self):
         """ToDo: Add docstring
         """
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         # The id attribute is a uuid
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
@@ -2476,9 +2309,7 @@ class TestNC2MMD(unittest.TestCase):
         with self.assertRaises(AttributeError):
             md.to_mmd()
         ncin = Dataset(md.netcdf_file)
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         value = md.get_metadata_identifier(mmd_yaml['metadata_identifier'], ncin)
         self.assertEqual(
             md.missing_attributes['errors'][0], 'id is a required attribute.'
@@ -2542,9 +2373,7 @@ class TestNC2MMD(unittest.TestCase):
         """
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_id_missing.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         lang = mmd_yaml['dataset_language']
         # Warnings are only issued when the field is required.
         # Currently, this is not the case for any of the fields
@@ -2587,9 +2416,7 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_create_mmd_missing_publisher_url(self):
         """Test that a missing publisher url does not cause an error"""
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(self.fail_nc, check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_data_centers(mmd_yaml['data_center'], ncin)
@@ -2605,9 +2432,7 @@ class TestNC2MMD(unittest.TestCase):
         """Test that an error is reported if date_created attribute is
         missing from the netcdf file.
         """
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(self.fail_nc, check_only=True)
         ncin = Dataset(md.netcdf_file)
         md.get_metadata_updates(mmd_yaml['last_metadata_update'], ncin)
@@ -2622,9 +2447,7 @@ class TestNC2MMD(unittest.TestCase):
         need to check that what we get from the netcdf file is an
         actual list, and that the items are actual datestrings.
         """
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(self.reference_nc, check_only=True)
         # To overwrite date_created, wihtout saving it to file we use diskless
         ncin = Dataset(md.netcdf_file)
@@ -2637,9 +2460,7 @@ class TestNC2MMD(unittest.TestCase):
         """ Test that an error is raised if datetimes of metadata
         updates are not ISO 8601.
         """
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(self.fail_nc, check_only=True)
         # To overwrite date_created, wihtout saving it to file we use diskless
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
@@ -2653,9 +2474,7 @@ class TestNC2MMD(unittest.TestCase):
     def test_ACDD_attr__date_created(self):
         """Test date_created is handled as it should
         """
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(self.fail_nc, check_only=True)
         # To overwrite date_created, wihtout saving it to file we use diskless
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
@@ -2673,9 +2492,7 @@ class TestNC2MMD(unittest.TestCase):
         between the fields in mmd_elements.yaml and the hardcoded
         fields in the get_metadata_updates function.
         """
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         in_dict = mmd_yaml['last_metadata_update']
         in_dict['update']['datetime']['acdd'] = {
             'new_name_for_date_created': {},  # this will cause an error
@@ -2687,15 +2504,11 @@ class TestNC2MMD(unittest.TestCase):
         self.assertTrue(
             'ACDD attribute inconsistency in mmd_elements.yaml' in str(context1.exception)
         )
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
 
     def test_create_mmd_missing_abstract(self):
         """ToDo: Add docstring"""
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(self.fail_nc, check_only=True)
         ncin = Dataset(md.netcdf_file)
         md.get_abstracts(mmd_yaml['abstract'], ncin)
@@ -2706,9 +2519,7 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_publication_date(self):
         """ToDo: Add docstring"""
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
         value = md.get_dataset_citations(mmd_yaml['dataset_citation'], ncin)
@@ -2843,9 +2654,7 @@ class TestNC2MMD(unittest.TestCase):
         """Test that a valid institution string passed as longname (shortname)
         is parsed correctly.
         """
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(self.fail_nc, check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.institution = "Norwegian Meteorological Institute (MET Norway)"
@@ -2856,9 +2665,7 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_institution_short_name_missing(self):
         """Test that if shortname is missing from institution an error is raised."""
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(self.fail_nc, check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.institution = "Norwegian Meteorological Institute"
@@ -2870,9 +2677,7 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_acdd_references_as_related_information1(self):
         """ Test that references (doi/uri) are correctly retrieved."""
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(self.reference_nc, check_only=True)
         ncin = Dataset(md.netcdf_file)
         data = md.get_related_information(mmd_yaml['related_information'], ncin)
@@ -2885,9 +2690,7 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_acdd_references_as_related_information2(self):
         """ Test that references (doi/uri) are correctly retrieved."""
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(self.fail_nc, check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.references = (
@@ -2910,9 +2713,7 @@ class TestNC2MMD(unittest.TestCase):
         types are not in the MMD controlled vocabulary for related
         information types.
         """
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(self.fail_nc, check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.references = (
@@ -2933,9 +2734,7 @@ class TestNC2MMD(unittest.TestCase):
         """ Test that an error message is created if the reference
         uri is invalid.
         """
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(self.fail_nc, check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.references = (
@@ -2955,9 +2754,7 @@ class TestNC2MMD(unittest.TestCase):
         """ Test that an error message is created if the references
         are not valid uris.
         """
-        mmd_yaml = yaml.load(
-            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
-        )
+        mmd_yaml = _mmd_yaml()
         md = Nc_to_mmd(self.fail_nc, check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
         ncin.references = "landing_page, paper"

--- a/tests/test_nc_to_mmd.py
+++ b/tests/test_nc_to_mmd.py
@@ -23,7 +23,7 @@ from dateutil.parser import isoparse
 from filehash import FileHash
 from lxml import etree
 from netCDF4 import Dataset
-from pkg_resources import resource_string
+from importlib.resources import files
 from unittest.mock import patch
 
 from py_mmd_tools.nc_to_mmd import Nc_to_mmd, normalize_iso8601, normalize_iso8601_0
@@ -140,7 +140,7 @@ def test_license_missing(dataDir):
     """ Test that an error is raised if the license attribute is missing.
     """
     mmd_yaml = yaml.load(
-        resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+        files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
     )
     # nc_to_update.nc does not have license..
     md = Nc_to_mmd(os.path.join(dataDir, "nc_to_update.nc"), check_only=True)
@@ -162,6 +162,7 @@ def test_separate_repeated(dataDir):
     with pytest.raises(AttributeError) as ee:
         md.separate_repeated(True, getattr(ncin, "platform"))
     assert str(ee.value) == "'list' object has no attribute 'split'"
+    ncin.close()
 
 
 @pytest.mark.py_mmd_tools
@@ -181,10 +182,11 @@ def testNc_to_mmd_get_geographic_extent_polygon(dataDir):
                               "60.33 0.64, 60.18 0.71, 60.03 0.77, 59.89 0.84, 59.74 0.90, "
                               "59.59 0.97, 59.45 1.03, 59.30 1.10, 59.15 1.16, 59.01 1.23))")
     mmd_yaml = yaml.load(
-        resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+        files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
     )
     data = md.get_geographic_extent_polygon(mmd_yaml["geographic_extent"].pop("polygon"), ncin)
     assert data["srsName"] == "EPSG:4326"
+    ncin.close()
 
 
 @pytest.mark.py_mmd_tools
@@ -192,7 +194,7 @@ def test_get_related_dataset(dataDir):
     """ Test get_related_dataset function.
     """
     mmd_yaml = yaml.load(
-        resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+        files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
     )
     # One related dataset
     md = Nc_to_mmd(os.path.join(dataDir, 'reference_nc.nc'), check_only=True)
@@ -262,7 +264,7 @@ def testNc_to_mmd_Get_acdd_metadata(dataDir):
     is covered for the boolean True case.
     """
     mmd_yaml = yaml.load(
-        resource_string("py_mmd_tools", "mmd_elements.yaml"), Loader=yaml.FullLoader
+        files("py_mmd_tools").joinpath("mmd_elements.yaml").read_bytes(), Loader=yaml.FullLoader
     )
     key = "dataset_production_status"
     test_in = os.path.join(dataDir, "reference_nc.nc")
@@ -438,7 +440,7 @@ def test_not_absolute_path():
 @pytest.mark.py_mmd_tools
 def test_get_operational_status(dataDir, monkeypatch):
     mmd_yaml = yaml.load(
-        resource_string("py_mmd_tools", "mmd_elements.yaml"), Loader=yaml.FullLoader
+        files("py_mmd_tools").joinpath("mmd_elements.yaml").read_bytes(), Loader=yaml.FullLoader
     )
     mmd_element = mmd_yaml["operational_status"]
     test_in = os.path.join(dataDir, "reference_nc.nc")
@@ -466,7 +468,7 @@ def test_get_operational_status(dataDir, monkeypatch):
 @pytest.mark.py_mmd_tools
 def test_dataset_production_status(dataDir):
     mmd_yaml = yaml.load(
-        resource_string("py_mmd_tools", "mmd_elements.yaml"), Loader=yaml.FullLoader
+        files("py_mmd_tools").joinpath("mmd_elements.yaml").read_bytes(), Loader=yaml.FullLoader
     )
     mmd_element = mmd_yaml["dataset_production_status"]
     test_in = os.path.join(dataDir, "reference_nc.nc")
@@ -494,7 +496,7 @@ def test_dataset_production_status(dataDir):
 @pytest.mark.py_mmd_tools
 def test_get_quality_control(dataDir):
     mmd_yaml = yaml.load(
-        resource_string("py_mmd_tools", "mmd_elements.yaml"), Loader=yaml.FullLoader
+        files("py_mmd_tools").joinpath("mmd_elements.yaml").read_bytes(), Loader=yaml.FullLoader
     )
     mmd_element = mmd_yaml["quality_control"]
     test_in = os.path.join(dataDir, "reference_nc.nc")
@@ -676,7 +678,7 @@ class TestNCAttrsFromYaml(unittest.TestCase):
         """
         self.maxDiff = None
         self.mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         self.attributes = {}
         self.attributes['acdd'] = {}
@@ -944,7 +946,7 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_license__deprecated_attrs(self):
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.reference_nc, check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
@@ -959,7 +961,7 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_license__invalid_url(self):
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.reference_nc, check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
@@ -976,7 +978,7 @@ class TestNC2MMD(unittest.TestCase):
         identifier is accepted and parsed correctly.
         """
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.reference_nc, check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
@@ -989,7 +991,7 @@ class TestNC2MMD(unittest.TestCase):
         """Test that a license with valid url only is accepted and parsed correctly.
         """
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.reference_nc, check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
@@ -1006,7 +1008,7 @@ class TestNC2MMD(unittest.TestCase):
         license causes an error.
         """
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.reference_nc, check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
@@ -1024,7 +1026,7 @@ class TestNC2MMD(unittest.TestCase):
         """Test that a license passed as url(identifier) is accepted and parsed correctly.
         """
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.reference_nc, check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
@@ -1037,7 +1039,7 @@ class TestNC2MMD(unittest.TestCase):
         """Test that a license passed as url (identifier) is accepted and parsed correctly.
         """
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.reference_nc, check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
@@ -1051,7 +1053,7 @@ class TestNC2MMD(unittest.TestCase):
         as license_text.
         """
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.reference_nc, check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
@@ -1085,7 +1087,7 @@ class TestNC2MMD(unittest.TestCase):
         or acdd_ext fields are present.
         """
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
@@ -1101,7 +1103,7 @@ class TestNC2MMD(unittest.TestCase):
         fields.
         """
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
@@ -1118,7 +1120,7 @@ class TestNC2MMD(unittest.TestCase):
         """Test that the get_acdd_metadata function uses default
         date_created_type."""
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
@@ -1130,7 +1132,7 @@ class TestNC2MMD(unittest.TestCase):
         Test that this case is properly handled.
         """
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.fail_nc, check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
@@ -1146,7 +1148,7 @@ class TestNC2MMD(unittest.TestCase):
     def test_geographic_extent_polygon(self):
         """ToDo: Add docstring"""
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
@@ -1159,7 +1161,7 @@ class TestNC2MMD(unittest.TestCase):
     def test_missing_nc_attrs(self):
         """ToDo: Add docstring"""
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_missing_attrs.nc'),
                        check_only=True)
@@ -1182,7 +1184,7 @@ class TestNC2MMD(unittest.TestCase):
         This test checks that this translates correctly.
         """
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
@@ -1198,7 +1200,7 @@ class TestNC2MMD(unittest.TestCase):
     def test_geographic_extent_is_string(self):
         """Check that the content is actually string type."""
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
@@ -1219,7 +1221,7 @@ class TestNC2MMD(unittest.TestCase):
         become '41.75999999999999'.
         """
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
@@ -1239,7 +1241,7 @@ class TestNC2MMD(unittest.TestCase):
         converted to float.
         """
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
@@ -1258,7 +1260,7 @@ class TestNC2MMD(unittest.TestCase):
         as a kwarg.
         """
         yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_missing_rectangle.nc'),
                        check_only=True)
@@ -1299,7 +1301,7 @@ class TestNC2MMD(unittest.TestCase):
     def test_abstract(self):
         """ToDo: Add docstring"""
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
@@ -1311,7 +1313,7 @@ class TestNC2MMD(unittest.TestCase):
     def test_title(self):
         """ToDo: Add docstring"""
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
@@ -1328,7 +1330,7 @@ class TestNC2MMD(unittest.TestCase):
     def test_title_one_language_only(self):
         """ToDo: Add docstring"""
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_id_missing.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
@@ -1343,7 +1345,7 @@ class TestNC2MMD(unittest.TestCase):
     def test_data_center(self):
         """Test get_data_centers function"""
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
@@ -1359,7 +1361,7 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_data_access(self):
         """ToDo: Add docstring"""
-        yaml.load(resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader)
+        yaml.load(files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader)
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         Dataset(md.netcdf_file)
         value = None
@@ -1368,7 +1370,7 @@ class TestNC2MMD(unittest.TestCase):
     def test_dataset_production_status(self):
         """ToDo: Add docstring"""
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
@@ -1383,7 +1385,7 @@ class TestNC2MMD(unittest.TestCase):
         attributes of the nc-file.
         """
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
@@ -1395,7 +1397,7 @@ class TestNC2MMD(unittest.TestCase):
         is missing the type between parentheses.
         """
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_with_altID.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
@@ -1414,7 +1416,7 @@ class TestNC2MMD(unittest.TestCase):
         provided in the nc-file.
         """
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_with_altID.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
@@ -1429,7 +1431,7 @@ class TestNC2MMD(unittest.TestCase):
         provided in the nc-file.
         """
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_with_altID_multiple.nc'),
                        check_only=True)
@@ -1444,7 +1446,7 @@ class TestNC2MMD(unittest.TestCase):
     def test_metadata_status_is_active(self):
         """ToDo: Add docstring"""
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
@@ -1454,7 +1456,7 @@ class TestNC2MMD(unittest.TestCase):
     def test_last_metadata_update(self):
         """ToDo: Add docstring"""
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
@@ -1464,7 +1466,7 @@ class TestNC2MMD(unittest.TestCase):
     def test_use_defaults_for_personnel(self):
         """ToDo: Add docstring"""
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(
             os.path.abspath(os.path.abspath('tests/data/reference_nc_missing_attrs.nc')),
@@ -1479,7 +1481,7 @@ class TestNC2MMD(unittest.TestCase):
     def test_missing_temporal_extent(self):
         """ToDo: Add docstring"""
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_missing_attrs.nc'),
                        check_only=True)
@@ -1494,7 +1496,7 @@ class TestNC2MMD(unittest.TestCase):
     def test_missing_temporal_extent_but_start_provided_in_dict(self):
         """ToDo: Add docstring"""
         yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_missing_attrs.nc'),
                        check_only=True)
@@ -1505,7 +1507,7 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_missing_temporal_extent_but_start_and_end_provided_in_dict(self):
         """ToDo: Add docstring"""
-        yaml.load(resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader)
+        yaml.load(files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader)
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_missing_attrs.nc'),
                        check_only=True)
         with self.assertRaises(AttributeError):
@@ -1517,7 +1519,7 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_missing_temporal_extent_but_start_and_end_provided_in_dict_and_wrong(self):
         """Test that errors are raised when input times are not iso"""
-        yaml.load(resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader)
+        yaml.load(files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader)
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_missing_attrs.nc'),
                        check_only=True)
         with self.assertRaises(AttributeError):
@@ -1537,7 +1539,7 @@ class TestNC2MMD(unittest.TestCase):
         translation to MMD.
         """
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_attrs_multiple.nc'),
                        check_only=True)
@@ -1554,7 +1556,7 @@ class TestNC2MMD(unittest.TestCase):
         translation to MMD.
         """
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_attrs_multiple.nc'),
                        check_only=True)
@@ -1619,7 +1621,7 @@ class TestNC2MMD(unittest.TestCase):
     def test_temporal_extent(self):
         """ToDo: Add docstring"""
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
@@ -1632,7 +1634,7 @@ class TestNC2MMD(unittest.TestCase):
         don't have the same number of comma separated entries.
         """
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(
             os.path.abspath('tests/data/reference_nc_attrs_multiple_mixed_creator.nc'),
@@ -1650,7 +1652,7 @@ class TestNC2MMD(unittest.TestCase):
     def test_personnel_multiple(self):
         """ToDo: Add docstring"""
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_attrs_multiple.nc'),
                        check_only=True)
@@ -1666,7 +1668,7 @@ class TestNC2MMD(unittest.TestCase):
     def test_personnel_multiple_creator_and_contributor(self):
         """Test that we can have multiple people in MMD personnel field"""
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(
             os.path.abspath('tests/data/reference_nc_attrs_multiple_and_contributor.nc'),
@@ -1690,7 +1692,7 @@ class TestNC2MMD(unittest.TestCase):
     def test_personnel_acdd_roles_not_list(self):
         """Test that we can have multiple people in MMD personnel field"""
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(
             os.path.abspath('tests/data/reference_nc_attrs_multiple_and_contributor.nc'),
@@ -1709,7 +1711,7 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_get_personnel_role_invalid(self):
         mmd_yaml = yaml.load(
-            resource_string("py_mmd_tools", "mmd_elements.yaml"), Loader=yaml.FullLoader
+            files("py_mmd_tools").joinpath("mmd_elements.yaml").read_bytes(), Loader=yaml.FullLoader
         )
         mmd_element = mmd_yaml["personnel"]
         test_in = os.path.abspath('tests/data/reference_nc.nc')
@@ -1724,7 +1726,7 @@ class TestNC2MMD(unittest.TestCase):
     def test_personnel(self):
         """Test reading of personnel from nc file into MMD"""
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
@@ -1734,7 +1736,7 @@ class TestNC2MMD(unittest.TestCase):
     def test_iso_topic_category(self):
         """ToDo: Add docstring"""
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
@@ -1747,7 +1749,7 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_get_iso_topic_category_invalid(self):
         mmd_yaml = yaml.load(
-            resource_string("py_mmd_tools", "mmd_elements.yaml"), Loader=yaml.FullLoader
+            files("py_mmd_tools").joinpath("mmd_elements.yaml").read_bytes(), Loader=yaml.FullLoader
         )
         mmd_element = mmd_yaml["iso_topic_category"]
         test_in = os.path.abspath('tests/data/reference_nc.nc')
@@ -1761,7 +1763,7 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_get_iso_topic_category_not_available(self):
         mmd_yaml = yaml.load(
-            resource_string("py_mmd_tools", "mmd_elements.yaml"), Loader=yaml.FullLoader
+            files("py_mmd_tools").joinpath("mmd_elements.yaml").read_bytes(), Loader=yaml.FullLoader
         )
         mmd_element = mmd_yaml["iso_topic_category"]
         test_in = os.path.abspath('tests/data/reference_nc.nc')
@@ -1777,7 +1779,7 @@ class TestNC2MMD(unittest.TestCase):
         the list https://htmlpreview.github.io/?https://github.com/metno/mmd/blob/
         master/doc/mmd-specification.html#activity-type"""
         mmd_yaml = yaml.load(
-            resource_string("py_mmd_tools", "mmd_elements.yaml"), Loader=yaml.FullLoader
+            files("py_mmd_tools").joinpath("mmd_elements.yaml").read_bytes(), Loader=yaml.FullLoader
         )
         mmd_element = mmd_yaml["activity_type"]
         test_in = os.path.abspath('tests/data/reference_nc.nc')
@@ -1796,7 +1798,7 @@ class TestNC2MMD(unittest.TestCase):
         in the netcdf file is GCMD.
         """
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_missing_keywords_vocab.nc'),
                        check_only=True)
@@ -1817,7 +1819,7 @@ class TestNC2MMD(unittest.TestCase):
         vocabulary url.
         """
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_missing_keywords_vocab.nc'),
                        check_only=True)
@@ -1842,7 +1844,7 @@ class TestNC2MMD(unittest.TestCase):
         other valid resource url.
         """
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.fail_nc, check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
@@ -1864,7 +1866,7 @@ class TestNC2MMD(unittest.TestCase):
         long name.
         """
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.fail_nc, check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
@@ -1884,7 +1886,7 @@ class TestNC2MMD(unittest.TestCase):
         <instrument long name>(<instrument short name>).
         """
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.fail_nc, check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
@@ -1906,7 +1908,7 @@ class TestNC2MMD(unittest.TestCase):
         TODO: Find a platform where this is actually the case...
         """
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.fail_nc, check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
@@ -1922,7 +1924,7 @@ class TestNC2MMD(unittest.TestCase):
         """ Test that parentheses in the long name are allowed
         """
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.fail_nc, check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
@@ -1940,7 +1942,7 @@ class TestNC2MMD(unittest.TestCase):
         https://vocab.met.no/mmd/en/page/Platform.
         """
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.fail_nc, check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
@@ -1964,7 +1966,7 @@ class TestNC2MMD(unittest.TestCase):
         provided.
         """
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_missing_keywords_vocab.nc'),
                        check_only=True)
@@ -1992,7 +1994,7 @@ class TestNC2MMD(unittest.TestCase):
     def test_keywords_missing(self):
         """ToDo: Add docstring"""
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_fail.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
@@ -2012,7 +2014,7 @@ class TestNC2MMD(unittest.TestCase):
         as short_name:long_name:url
         """
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.fail_nc, check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
@@ -2032,7 +2034,7 @@ class TestNC2MMD(unittest.TestCase):
         of a vocabulary is wrong.
         """
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.fail_nc, check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
@@ -2060,7 +2062,7 @@ class TestNC2MMD(unittest.TestCase):
         removed.
         """
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.fail_nc, check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
@@ -2080,7 +2082,7 @@ class TestNC2MMD(unittest.TestCase):
     def test_keywords_vocabulary_missing(self):
         """ToDo: Add docstring"""
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_missing_keywords_vocab.nc'),
                        check_only=True)
@@ -2096,7 +2098,7 @@ class TestNC2MMD(unittest.TestCase):
         not exist.
         """
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_non_cf_standard_name.nc'),
                        check_only=True)
@@ -2111,7 +2113,7 @@ class TestNC2MMD(unittest.TestCase):
     def test_keywords(self):
         """ToDo: Add docstring"""
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
@@ -2139,7 +2141,7 @@ class TestNC2MMD(unittest.TestCase):
     def test_keywords_multiple(self):
         """ToDo: Add docstring"""
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_attrs_multiple.nc'),
                        check_only=True)
@@ -2158,7 +2160,7 @@ class TestNC2MMD(unittest.TestCase):
     def test_platforms(self):
         """ToDo: Add docstring"""
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
@@ -2177,7 +2179,7 @@ class TestNC2MMD(unittest.TestCase):
         vocabulary different from MMD is used, and that we use what
         we get."""
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_gcmd_platform.nc'),
                        check_only=True)
@@ -2199,7 +2201,7 @@ class TestNC2MMD(unittest.TestCase):
     def test_projects(self):
         """Test getting project information from nc-file"""
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
@@ -2209,7 +2211,7 @@ class TestNC2MMD(unittest.TestCase):
     def test_projects_with_short_name(self):
         """Test getting project information with short name from nc-file"""
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_project_with_short_name.nc'),
                        check_only=True)
@@ -2221,7 +2223,7 @@ class TestNC2MMD(unittest.TestCase):
     def test_projects_missing(self):
         """Test getting project information when this is missing"""
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_missing_project.nc'),
                        check_only=True)
@@ -2232,7 +2234,7 @@ class TestNC2MMD(unittest.TestCase):
     def test_projects_malformed(self):
         """Test getting project information when this is malformed"""
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_malformed_project.nc'),
                        check_only=True)
@@ -2245,7 +2247,7 @@ class TestNC2MMD(unittest.TestCase):
     def test_dataset_citation_missing_attrs(self):
         """Test that missing url and other is accepted"""
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_missing_keywords_vocab.nc'),
                        check_only=True)
@@ -2266,7 +2268,7 @@ class TestNC2MMD(unittest.TestCase):
             "publication_date": "2023-07-06",
             "title": "Some random title"}
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.fail_nc, check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
@@ -2299,7 +2301,7 @@ class TestNC2MMD(unittest.TestCase):
     def test_dataset_citation(self):
         """ToDo: Add docstring"""
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
@@ -2319,7 +2321,7 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_dataset_citation_invalid_date(self):
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
@@ -2337,7 +2339,7 @@ class TestNC2MMD(unittest.TestCase):
         # the correct format
         ncin.date_created = "2020-99-28 13:51:24"
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         value = md.get_dataset_citations(mmd_yaml['dataset_citation'], ncin)
         self.assertIn(
@@ -2366,7 +2368,7 @@ class TestNC2MMD(unittest.TestCase):
         from mmd_elements.yaml.
         """
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         # Only one value in the list
         mmd_yaml['metadata_identifier']['acdd'] = {'id': {}}
@@ -2402,7 +2404,7 @@ class TestNC2MMD(unittest.TestCase):
         # Change the valid naming authorities to force an error
         md.VALID_NAMING_AUTHORITIES = ['jada.no']
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md.get_metadata_identifier(mmd_yaml['metadata_identifier'], ncin)
         self.assertEqual(
@@ -2412,7 +2414,7 @@ class TestNC2MMD(unittest.TestCase):
 
     def test_to_mmd_warning_not_empty(self):
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         mmd_yaml['dummy_field'] = {}
         mmd_yaml['dummy_field']['minOccurs'] = '1'
@@ -2434,7 +2436,7 @@ class TestNC2MMD(unittest.TestCase):
         is not an uuid.
         """
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         # The id attribute is not a uuid
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_fail.nc'), check_only=True)
@@ -2457,7 +2459,7 @@ class TestNC2MMD(unittest.TestCase):
         """ToDo: Add docstring
         """
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         # The id attribute is a uuid
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
@@ -2475,7 +2477,7 @@ class TestNC2MMD(unittest.TestCase):
             md.to_mmd()
         ncin = Dataset(md.netcdf_file)
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         value = md.get_metadata_identifier(mmd_yaml['metadata_identifier'], ncin)
         self.assertEqual(
@@ -2541,7 +2543,7 @@ class TestNC2MMD(unittest.TestCase):
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc_id_missing.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         lang = mmd_yaml['dataset_language']
         # Warnings are only issued when the field is required.
@@ -2586,7 +2588,7 @@ class TestNC2MMD(unittest.TestCase):
     def test_create_mmd_missing_publisher_url(self):
         """Test that a missing publisher url does not cause an error"""
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.fail_nc, check_only=True)
         ncin = Dataset(md.netcdf_file)
@@ -2604,7 +2606,7 @@ class TestNC2MMD(unittest.TestCase):
         missing from the netcdf file.
         """
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.fail_nc, check_only=True)
         ncin = Dataset(md.netcdf_file)
@@ -2621,7 +2623,7 @@ class TestNC2MMD(unittest.TestCase):
         actual list, and that the items are actual datestrings.
         """
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.reference_nc, check_only=True)
         # To overwrite date_created, wihtout saving it to file we use diskless
@@ -2636,7 +2638,7 @@ class TestNC2MMD(unittest.TestCase):
         updates are not ISO 8601.
         """
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.fail_nc, check_only=True)
         # To overwrite date_created, wihtout saving it to file we use diskless
@@ -2652,7 +2654,7 @@ class TestNC2MMD(unittest.TestCase):
         """Test date_created is handled as it should
         """
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.fail_nc, check_only=True)
         # To overwrite date_created, wihtout saving it to file we use diskless
@@ -2672,7 +2674,7 @@ class TestNC2MMD(unittest.TestCase):
         fields in the get_metadata_updates function.
         """
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         in_dict = mmd_yaml['last_metadata_update']
         in_dict['update']['datetime']['acdd'] = {
@@ -2686,13 +2688,13 @@ class TestNC2MMD(unittest.TestCase):
             'ACDD attribute inconsistency in mmd_elements.yaml' in str(context1.exception)
         )
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
 
     def test_create_mmd_missing_abstract(self):
         """ToDo: Add docstring"""
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.fail_nc, check_only=True)
         ncin = Dataset(md.netcdf_file)
@@ -2705,7 +2707,7 @@ class TestNC2MMD(unittest.TestCase):
     def test_publication_date(self):
         """ToDo: Add docstring"""
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(os.path.abspath('tests/data/reference_nc.nc'), check_only=True)
         ncin = Dataset(md.netcdf_file)
@@ -2842,7 +2844,7 @@ class TestNC2MMD(unittest.TestCase):
         is parsed correctly.
         """
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.fail_nc, check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
@@ -2855,7 +2857,7 @@ class TestNC2MMD(unittest.TestCase):
     def test_institution_short_name_missing(self):
         """Test that if shortname is missing from institution an error is raised."""
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.fail_nc, check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
@@ -2869,7 +2871,7 @@ class TestNC2MMD(unittest.TestCase):
     def test_acdd_references_as_related_information1(self):
         """ Test that references (doi/uri) are correctly retrieved."""
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.reference_nc, check_only=True)
         ncin = Dataset(md.netcdf_file)
@@ -2884,7 +2886,7 @@ class TestNC2MMD(unittest.TestCase):
     def test_acdd_references_as_related_information2(self):
         """ Test that references (doi/uri) are correctly retrieved."""
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.fail_nc, check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
@@ -2909,7 +2911,7 @@ class TestNC2MMD(unittest.TestCase):
         information types.
         """
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.fail_nc, check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
@@ -2932,7 +2934,7 @@ class TestNC2MMD(unittest.TestCase):
         uri is invalid.
         """
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.fail_nc, check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)
@@ -2954,7 +2956,7 @@ class TestNC2MMD(unittest.TestCase):
         are not valid uris.
         """
         mmd_yaml = yaml.load(
-            resource_string('py_mmd_tools', 'mmd_elements.yaml'), Loader=yaml.FullLoader
+            files('py_mmd_tools').joinpath('mmd_elements.yaml').read_bytes(), Loader=yaml.FullLoader
         )
         md = Nc_to_mmd(self.fail_nc, check_only=True)
         ncin = Dataset(md.netcdf_file, "w", diskless=True)


### PR DESCRIPTION
Replace deprecated pkg_resources.resource_string with importlib.resources.files().joinpath().read_bytes() across all source and test files. pkg_resources is no longer available without an explicit setuptools dependency in Python 3.12+.

Add missing `responsible_unit` field to storage_information in mmd_elements.yaml to match the MMD XSD schema.

Fix test isolation issue in test_nc_to_mmd.py by closing netCDF4 Dataset handles after use in test_separate_repeated and testNc_to_mmd_get_geographic_extent_polygon.

Update pyproject.toml:
- Replace Python 3.8 classifier with 3.12
- Set requires-python >= 3.9 (importlib.resources.files requires Python 3.9+)
- Relax netCDF4 constraint from ~=1.5 to >=1.5

Fixes #361

**Summary**: closes #361 

**Related issue**: #361 

**Suggested reviewer(s)**:

**Reviewer checklist**:

- [ ] The headers of all files contain a reference to the repository license (i.e., "License: This file is part of py-mmd-tools, licensed under the Apache License 2.0 (https://www.apache.org/licenses/LICENSE-2.0)")
- [ ] 100% test coverage of new code - meaning:
    - [ ] The overall test coverage increased or remained the same as before
    - [ ] Every function is accompanied with a test suite
    - [ ] Tests are both positive (testing that the function work as intended with valid data) and negative (testing that the function behaves as expected with invalid data, e.g., that correct exceptions are thrown)
    - [ ] Functions with optional arguments have separate tests for all options
- [ ] Examples are supported by doctests
- [ ] All tests are passing
- [ ] All names (e.g., files, classes, functions, variables) are explicit
- [ ] Documentation (as docstrings) is complete and understandable

The checklist is based on the S-ENDA conventions and definition of done (see https://s-enda-documentation.readthedocs.io/en/latest/general_conventions.html). The above points are not necessarily relevant to all contributions. In that case, please add a short explanation to help the reviewer.
